### PR TITLE
Add background-enabled "Services at a Glance" section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,21 +75,23 @@
       </div>
     </section>
 
-    <section class="services-preview" aria-labelledby="services-preview-title">
-      <h2 id="services-preview-title">Services at a glance</h2>
-      <div class="services-grid">
-        <article class="service-item">
-          <h3>In-home appointments</h3>
-          <p>Comfortable care in your own space, with gentle pacing.</p>
-        </article>
-        <article class="service-item">
-          <h3>In-studio appointments</h3>
-          <p>Visit a sensory-friendly home salon in Bourget, Ontario.</p>
-        </article>
-        <article class="service-item">
-          <h3>Sensory-considerate approach</h3>
-          <p>Flexible, respectful service tailored to your needs.</p>
-        </article>
+    <section class="services-glance-section" aria-labelledby="services-preview-title" style="--services-glance-bg: url('PASTE-IMAGE-URL-HERE');">
+      <div class="services-preview">
+        <h2 id="services-preview-title">Services at a Glance</h2>
+        <div class="services-grid">
+          <article class="service-item">
+            <h3>In-home appointments</h3>
+            <p>Comfortable care in your own space, with gentle pacing.</p>
+          </article>
+          <article class="service-item">
+            <h3>In-studio appointments</h3>
+            <p>Visit a sensory-friendly home salon in Bourget, Ontario.</p>
+          </article>
+          <article class="service-item">
+            <h3>Sensory-considerate approach</h3>
+            <p>Flexible, respectful service tailored to your needs.</p>
+          </article>
+        </div>
       </div>
     </section>
   </main>

--- a/style.css
+++ b/style.css
@@ -279,17 +279,38 @@ button:focus-visible {
   color: var(--text);
 }
 
+.services-glance-section {
+  --services-glance-bg: none;
+  position: relative;
+  padding: 3.5rem 0 4rem;
+  background-color: #f7f0f5;
+  background-image: var(--services-glance-bg);
+  background-size: cover;
+  background-position: center;
+}
+
+.services-glance-section::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.services-glance-section > * {
+  position: relative;
+}
+
 .services-preview {
   max-width: var(--section-max);
   margin: 0 auto;
-  padding: 0 1.25rem 3.5rem;
+  padding: 0 1.25rem;
 }
 
 .services-preview h2 {
   margin: 0 0 1rem 0;
   font-family: "Playfair Display", serif;
   color: var(--brand);
-  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  font-size: clamp(2.2rem, 4vw, 3.4rem);
 }
 
 .services-intro,


### PR DESCRIPTION
### Motivation
- Break the homepage at the "Services at a Glance" area to create a visually distinct section. 
- Allow an easy copy-paste background image URL that can be changed without modifying markup. 
- Make the "Services at a Glance" heading more prominent for better separation. 

### Description
- Replaced the original services block in `index.html` with a new `section.services-glance-section` that wraps the existing `services-preview` and includes a placeholder inline style `--services-glance-bg: url('PASTE-IMAGE-URL-HERE')` for easy image insertion. 
- Updated the heading text to `Services at a Glance` (capitalized) inside the new structure. 
- Added `.services-glance-section` rules to `style.css` to apply `background-image: var(--services-glance-bg)`, a centered `background-size: cover`, and a translucent overlay via `.services-glance-section::before`. 
- Adjusted `.services-preview` padding and increased `.services-preview h2` font-size via a `clamp()` to make the heading larger and responsive. 

### Testing
- Started a local static server with `python -m http.server 8000` to serve the site, which launched successfully. 
- Ran a Playwright screenshot script to visually validate the change, but the browser process crashed with a `SIGSEGV` and the screenshot failed. 
- No unit or integration test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962b71d3de083229d3e4767b8d4990e)