### PR TITLE
Compact footer and increased Services section bottom spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -287,7 +287,7 @@ button:focus-visible {
 
 .services-glance-section {
   position: relative;
-  padding: 3.5rem 0 4rem;
+  padding: 3.5rem 0 5.75rem;
   background-image: var(--services-glance-bg); /* Use background.png */
   background-size: cover;
   background-position: center;
@@ -444,7 +444,7 @@ button:focus-visible {
 }
 
 .site-footer {
-  padding: 2.5rem 1.25rem 3rem;
+  padding: 1.6rem 1.25rem 2.1rem;
   color: var(--muted);
 }
 
@@ -659,7 +659,7 @@ button:focus-visible {
 }
 
 .site-footer {
-  padding: 2.5rem 1.25rem 3rem;
+  padding: 1.6rem 1.25rem 2.1rem;
   color: var(--muted);
 }
 


### PR DESCRIPTION
### Motivation
- Reduce the footer's visual dominance by decreasing its overall height and padding to create a calmer page ending.  
- Give the “Services at a Glance” section more vertical breathing room so its background/gradient extends further before the footer.  
- Improve the visual flow between the section and the footer without changing content, fonts, colors, or adding elements.  
- Keep existing styling and content intact while only adjusting spacing and layout.

### Description
- Increased the bottom padding of `.services-glance-section` from `4rem` to `5.75rem` so the background/gradient extends further downward.  
- Reduced the footer padding in `.site-footer` from `2.5rem 1.25rem 3rem` to `1.6rem 1.25rem 2.1rem` (applied to both occurrences) to make the footer more compact.  
- No changes were made to text, fonts, colors, images, or structural HTML; only spacing values in `style.css` were modified.  
- Commit includes the updated `style.css` with the spacing adjustments.

### Testing
- Launched a local HTTP server and ran a Playwright visual smoke test that opened `index.html`, scrolled to the bottom, and captured `artifacts/services-footer.png`, and the script completed successfully.  
- The CSS change was committed and the repository shows the updated `style.css` tracked in version control.  
- No unit tests were added or required for this purely visual/layout change.  
- Manual visual review artifact `artifacts/services-footer.png` is available for confirmation of spacing improvements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e1a665dc8322b1743db04f1e3dee)