### PR TITLE
Improve responsive header/footer and clean CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,7 +17,7 @@
   --ui-font: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --decorative-welcome: "The Nautigal", cursive;
   --max-width: 1100px;
-  --header-offset: 110px;
+  --header-offset: 96px;
   --section-max: 1000px;
   --card-bg: rgba(255, 255, 255, 0.7);
   --card-border: rgba(255, 255, 255, 0.6);
@@ -115,6 +115,7 @@ button:focus-visible {
   max-width: 100%;
   margin: 0;
   padding: 0.75rem 2rem;
+  flex-wrap: nowrap;
 }
 
 .logo-box {
@@ -451,221 +452,6 @@ button:focus-visible {
 .footer-inner {
   max-width: var(--max-width);
   margin: 0 auto;
-  max-width: var(--max-width);
-  margin: 0 auto;
-  padding: 0.6rem 1.25rem;
-}
-
-.logo-box {
-  display: flex;
-  align-items: center;
-}
-
-.logo-img {
-  width: 180px;
-  height: auto;
-  display: block;
-}
-
-.header-divider {
-  width: 1px;
-  height: 44px;
-  background: rgba(0, 0, 0, 0.08);
-}
-
-.primary-nav ul {
-  list-style: none;
-  display: flex;
-  gap: 1.1rem;
-  margin: 0;
-  padding: 0;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.primary-nav a {
-  font-weight: 500;
-  color: var(--text);
-  padding: 0.35rem 0.25rem;
-  border-radius: 6px;
-}
-
-.primary-nav a[aria-current="page"] {
-  color: var(--brand);
-}
-
-.primary-nav a:hover {
-  color: var(--brand);
-}
-
-.header-social {
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  margin-left: auto;
-}
-
-.social-btn {
-  width: 36px;
-  height: 36px;
-  border-radius: 999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.social-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12);
-}
-
-.social-icon {
-  width: 18px;
-  height: 18px;
-}
-
-.site-main {
-  flex: 1;
-  padding-top: var(--header-offset);
-}
-
-.hero {
-  max-width: var(--max-width);
-  margin: 0 auto;
-  padding: 3.5rem 1.25rem 2.5rem;
-  display: grid;
-  gap: 1.5rem;
-}
-
-.hero-content {
-  max-width: 680px;
-}
-
-.hero-title {
-  font-family: var(--decorative-welcome);
-  font-size: clamp(2.6rem, 5vw, 4.2rem);
-  color: var(--brand);
-  margin: 0 0 0.4rem 0;
-  font-weight: 700;
-}
-
-.hero-subtitle {
-  font-size: clamp(1.05rem, 2.2vw, 1.25rem);
-  margin: 0 0 1.4rem 0;
-  color: var(--muted);
-}
-
-.hero-actions {
-  display: flex;
-  gap: 0.9rem;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.btn-primary {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  background: var(--brand);
-  color: #fff;
-  padding: 0.7rem 1.6rem;
-  border-radius: 999px;
-  font-weight: 600;
-  border: none;
-  box-shadow: 0 12px 24px rgba(122, 60, 122, 0.25);
-}
-
-.btn-primary:hover {
-  background: #5f2f5f;
-}
-
-.btn-secondary {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.65rem 1.4rem;
-  border-radius: 999px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  color: var(--text);
-  background: rgba(255, 255, 255, 0.6);
-}
-
-.hero-reassurance {
-  margin-top: 0.9rem;
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.intro-section {
-  max-width: var(--section-max);
-  margin: 0 auto;
-  padding: 0 1.25rem 2.5rem;
-}
-
-.intro-card {
-  background: var(--card-bg);
-  border: 1px solid var(--card-border);
-  border-radius: 24px;
-  padding: 2rem;
-  box-shadow: var(--card-shadow);
-  backdrop-filter: blur(8px);
-}
-
-.intro-text {
-  margin: 0 0 1rem 0;
-  font-size: 1.02rem;
-  color: var(--text);
-}
-
-.services-preview {
-  max-width: var(--section-max);
-  margin: 0 auto;
-  padding: 0 1.25rem 3.5rem;
-}
-
-.services-preview h2 {
-  margin: 0 0 1rem 0;
-  font-family: "Playfair Display", serif;
-  color: var(--brand);
-  font-size: clamp(1.5rem, 3vw, 2.1rem);
-}
-
-.services-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-}
-
-.service-item {
-  background: rgba(255, 255, 255, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.7);
-  border-radius: 20px;
-  padding: 1.2rem;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.06);
-}
-
-.service-item h3 {
-  margin: 0 0 0.4rem 0;
-  color: var(--brand);
-  font-size: 1.05rem;
-}
-
-.service-item p {
-  margin: 0;
-  color: var(--muted);
-}
-
-.site-footer {
-  padding: 1.6rem 1.25rem 2.1rem;
-  color: var(--muted);
-}
-
-.footer-inner {
-  max-width: var(--max-width);
-  margin: 0 auto;
 }
 
 .footer-brand {
@@ -701,26 +487,59 @@ button:focus-visible {
   font-size: 0.9rem;
 }
 
+/* Header responsive */
 @media (max-width: 900px) {
   .top-bar {
     flex-wrap: wrap;
+    row-gap: 12px;
   }
   .header-divider {
     display: none;
   }
+  .logo-box {
+    order: 1;
+  }
   .header-social {
-    width: 100%;
-    justify-content: flex-end;
-    margin-left: 0;
+    order: 2;
+    margin-left: auto;
+  }
+  .primary-nav {
+    order: 3;
+    flex: 1 1 100%;
   }
   .site-main {
-    padding-top: 140px;
+    padding-top: 120px;
   }
 }
 
 @media (max-width: 600px) {
+  .top-bar {
+    padding: 0.6rem 1.25rem;
+  }
   .logo-img {
     width: 150px;
+  }
+  .primary-nav ul {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    white-space: nowrap;
+    padding-bottom: 6px;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .primary-nav ul::-webkit-scrollbar {
+    display: none;
+  }
+  .primary-nav li {
+    flex: 0 0 auto;
+  }
+  .primary-nav a {
+    padding: 10px 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.6);
+  }
+  .site-main {
+    padding-top: 140px;
   }
   .hero {
     padding-top: 2.5rem;
@@ -733,40 +552,36 @@ button:focus-visible {
   }
 }
 
-}
-
-.footer-copyright {
-  font-size: 0.9rem;
-}
-
-@media (max-width: 900px) {
-  .top-bar {
-    flex-wrap: wrap;
+/* Footer responsive */
+@media (max-width: 700px) {
+  .footer-inner {
+    display: grid;
+    gap: 18px;
+    justify-items: center;
+    text-align: center;
   }
-  .header-divider {
+  .footer-brand {
+    justify-content: center;
+  }
+  .footer-divider {
     display: none;
   }
-  .header-social {
-    width: 100%;
-    justify-content: flex-end;
-    margin-left: 0;
+}
+
+@media (max-width: 480px) {
+  .footer-inner {
+    gap: 22px;
   }
-  .site-main {
-    padding-top: 140px;
+  .footer-photo {
+    width: 60px;
+    height: 60px;
+  }
+  .footer-copy {
+    gap: 0.35rem;
   }
 }
 
-@media (max-width: 600px) {
-  .logo-img {
-    width: 150px;
-  }
-  .hero {
-    padding-top: 2.5rem;
-  }
-  .intro-card {
-    padding: 1.5rem;
-  }
-}
+/* Cleanup: removed duplicates */
 
 /* Scrollbar styling */
 * {


### PR DESCRIPTION
### Motivation
- Make the site header and footer reliably mobile-friendly by preventing cramped nav pills, wrapping chaos, and overlap while keeping the header fixed.
- Stabilize styling by removing duplicated CSS blocks and fixing a stray unmatched brace that caused parsing/responsive unpredictability.
- Preserve existing colors and typography while improving spacing and tap targets for accessibility on small screens.
- Provide a safer header offset strategy so main content never hides behind the fixed header across breakpoints.

### Description
- Reduced `--header-offset` from `110px` to `96px` and added breakpoint-aware `padding-top` adjustments for `.site-main` to match header height on `@media` rules.
- Consolidated and removed duplicate selector blocks (header, nav, hero, footer, etc.) and removed the stray `}` so the file parses cleanly, with a new `/* Cleanup: removed duplicates */` comment.
- Implemented responsive header rules: `.top-bar` wrapping behavior, hidden `.header-divider` on smaller screens, ordering so logo + social icons sit on row 1 and nav moves to row 2, and reduced header padding on mobile; added the `/* Header responsive */` comment.
- Implemented mobile nav UX: nav becomes a horizontally scrollable pill-style row at `<=600px` with `overflow-x: auto`, hidden scrollbar for the nav, and increased tap target padding for `.primary-nav a`; and implemented footer stacking rules under `/* Footer responsive */` for `<=700px` and `<=480px`.

### Testing
- Served the site locally using `python -m http.server` on port 8000 and confirmed the server started successfully (server process ran). 
- Attempted an automated mobile screenshot using `Playwright` to validate rendering, but the headless browser crashed and the screenshot step failed due to environment/browser launch errors.
- Ran a quick text search (`rg`) to confirm duplicate header/footer selectors were removed and unique definitions remain, which succeeded.
- No automated CSS linter was run as part of this change, so visual QA is recommended in browsers after deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69630d2ddb388322857c4f3f348f4162)