### PR TITLE
Add responsive SVG wave divider to Services section

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,11 @@
     </section>
 
     <section class="services-glance-section" aria-labelledby="services-preview-title" style="--services-glance-bg: url('background.png');">
+      <div class="section-divider section-divider--top" aria-hidden="true">
+        <svg viewBox="0 0 1440 120" preserveAspectRatio="none" role="presentation" focusable="false">
+          <path fill="#FCF0F7" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
+        </svg>
+      </div>
       <div class="services-preview">
         <h2 id="services-preview-title">Services at a Glance</h2>
         <div class="services-grid">

--- a/style.css
+++ b/style.css
@@ -288,7 +288,8 @@ button:focus-visible {
 
 .services-glance-section {
   position: relative;
-  padding: 3.5rem 0 5.75rem;
+  --divider-height: clamp(70px, 12vw, 130px);
+  padding: calc(3.5rem + var(--divider-height)) 0 5.75rem;
   background-image: var(--services-glance-bg); /* Use background.png */
   background-size: cover;
   background-position: center;
@@ -299,11 +300,30 @@ button:focus-visible {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(255, 255, 255, 0.78);
+  background: rgba(255, 255, 255, 0.62);
+  z-index: 0;
 }
 
 .services-glance-section > * {
   position: relative;
+  z-index: 1;
+}
+
+/* Services split divider */
+.section-divider {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--divider-height);
+  display: block;
+  pointer-events: none;
+}
+
+.section-divider svg {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .services-preview {


### PR DESCRIPTION
### Motivation
- Create a distinct, premium “split” transition into the Services-at-a-Glance area using a decorative top wave. 
- Keep the existing textured `background.png` but make the overlay calmer so the texture is visible and intentional. 
- Reserve spacing so the wave does not overlap the `Services at a Glance` heading and the section breathes on mobile and desktop. 
- Maintain existing page gradients, header, intro, and service card styles while only adjusting minor spacing/layering.

### Description
- Inserted a decorative divider inside the `section.services-glance-section` before `.services-preview` containing an inline SVG wave with `preserveAspectRatio="none"` and fill `#FCF0F7` for a soft near-white tone. 
- Added a responsive CSS variable `--divider-height: clamp(70px, 12vw, 130px)` and increased the section top padding using `padding: calc(3.5rem + var(--divider-height))` so the heading sits below the wave. 
- Tuned the overlay from `rgba(255,255,255,0.78)` to `rgba(255,255,255,0.62)` and adjusted stacking with `z-index` so the layering order is: background -> `::before` overlay -> divider + content. 
- Added `.section-divider` rules and ensured SVG is `display: block; width: 100%; height: 100%;` so the wave scales responsively (desktop ~100–130px, mobile ~70–100px).

### Testing
- Served the site locally with `python -m http.server` to validate static assets and HTTP responses, which returned `200 OK`. 
- Captured visual verification screenshots using a Playwright script at a desktop viewport and saved `artifacts/services-glance-section.png`, confirming the divider placement and texture visibility (succeeded). 
- Multiple automated page-check attempts were made to ensure the `.services-glance-section` selector was present and renderable (visual check succeeded via screenshot). 
- No unit tests were applicable since changes are static HTML/CSS visual adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963102748c88322a63457d55c555952)