### PR TITLE
Refine hero-to-services transition — gradient, responsive wave with scissors image

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,8 +113,13 @@
 
     <section class="services-glance-section" aria-labelledby="services-preview-title" style="--services-glance-bg: url('background.png');">
       <div class="section-divider section-divider--top" aria-hidden="true">
-        <svg viewBox="0 0 1440 120" preserveAspectRatio="none" role="presentation" focusable="false">
-          <path fill="#FCF0F7" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
+          <defs>
+            <pattern id="scissors-wave" patternUnits="userSpaceOnUse" width="1440" height="140">
+              <image href="background.png" width="1440" height="140" preserveAspectRatio="xMidYMid slice"></image>
+            </pattern>
+          </defs>
+          <path fill="url(#scissors-wave)" d="M0,0 H1440 V30 C1200,120 900,130 720,110 C480,90 240,80 0,110 Z"></path>
         </svg>
       </div>
       <div class="services-preview">

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:wght@400;600&family=The+Nautigal:wght@400;700&display=swap');
 
 :root {
-  --bg-gradient: linear-gradient(135deg, #F0F7FC 0%, #FFFAFE 45%, #F0F7FC 100%);
+  --bg-gradient: linear-gradient(135deg, #FFE3EC 0%, #E3FDFF 50%, #E3E3FF 100%);
   --services-glance-bg: url('background.png'); 
   --text: #1f2328;
   --muted: #5f6368;
@@ -42,10 +42,7 @@ body {
   line-height: 1.6;
 
   /* Full-page gradient background */
-  background: linear-gradient(135deg, #FCF0F7 0%, #F7FCF0 45%, #F0F7FC 100%);
-  background-size: cover; /* Stretch to cover the viewport */
-  background-repeat: no-repeat; /* Prevent tiling */
-  background-attachment: fixed; /* Optional: Lock the gradient during scroll */
+  background: #fff;
 
   -webkit-font-smoothing: antialiased;
 }
@@ -193,6 +190,10 @@ button:focus-visible {
 .site-main {
   flex: 1;
   padding-top: var(--header-offset);
+  background: var(--bg-gradient);
+  background-repeat: no-repeat;
+  background-position: top center;
+  background-size: 100% clamp(420px, 70vh, 720px);
 }
 
 .hero {
@@ -292,21 +293,9 @@ button:focus-visible {
   padding: calc(3.5rem + var(--divider-height)) 0 5.75rem;
   background-image: var(--services-glance-bg); /* Use background.png */
   background-size: cover;
-  background-position: center;
+  background-position: center top;
   background-repeat: no-repeat;
   background-color: #f7f0f5; /* Fallback color */
-}
-.services-glance-section::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: rgba(255, 255, 255, 0.62);
-  z-index: 0;
-}
-
-.services-glance-section > * {
-  position: relative;
-  z-index: 1;
 }
 
 /* Services split divider */
@@ -318,6 +307,7 @@ button:focus-visible {
   height: var(--divider-height);
   display: block;
   pointer-events: none;
+  z-index: 0;
 }
 
 .section-divider svg {
@@ -330,6 +320,8 @@ button:focus-visible {
   max-width: var(--section-max);
   margin: 0 auto;
   padding: 0 1.25rem;
+  position: relative;
+  z-index: 1;
 }
 
 .services-preview h2 {
@@ -446,8 +438,8 @@ button:focus-visible {
   }
 }
 .service-item {
-  background: rgba(255, 255, 255, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.7);
+  background: #fff;
+  border: 1px solid rgba(225, 217, 229, 0.7);
   border-radius: 20px;
   padding: 1.2rem;
   box-shadow: 0 12px 30px rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
### Motivation
- Restore the hero top-half to the requested soft gradient palette `#FFE3EC`, `#E3FDFF`, `#E3E3FF` and keep the lower page visually clean.
- Rebuild the wavy section break so it renders crisply and responsively without skew/stretch artifacts.
- Ensure the scissors artwork (`background.png`) is visible inside the curved/wave area. 
- Remove frosted/glass overlay from the lower services half so only hero cards retain the blur effect.

### Description
- Updated the CSS `--bg-gradient` and moved the gradient to the `.site-main` background with controlled `background-size` so the top-half shows the exact palette. 
- Replaced the previous SVG divider with an inline SVG that uses a `<pattern>` + `<image href="background.png">` and a wave `path` so the scissors image fills the curve cleanly and responsively. 
- Removed the frosted overlay pseudo-element on `.services-glance-section` and adjusted stacking via `z-index` so hero content remains on top while the services section shows the plain background image. 
- Simplified service card styling by switching `.service-item` to a solid `#fff` background and a subtle border to avoid inheriting blur/overlay from the hero.

### Testing
- Launched a local static server with `python -m http.server 8000` to serve the updated site and the command started successfully. 
- Ran a Playwright script which navigated to `http://127.0.0.1:8000/index.html`, captured a full-page screenshot, and saved it as `artifacts/hero-services.png` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964397e7cac83228303df7a8a9fa79c)