### PR TITLE
Apply top-only gradient, reveal services background, match wave fill, and fix logo

### DIFF
--- a/bookings.html
+++ b/bookings.html
@@ -33,7 +33,7 @@
     <div class="top-bar">
       <div class="logo-box">
         <a href="index.html" class="logo-link" aria-label="InJoy Beauty home">
-          <img src="InjoyBeauty.jpg" alt="InJoy Beauty logo" class="logo-img" width="160" height="80" />
+          <img src="InjoyBeauty.png" alt="InJoy Beauty logo" class="logo-img" width="160" height="80" />
         </a>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
     <section class="services-glance-section" aria-labelledby="services-preview-title" style="--services-glance-bg: url('background.png');">
       <div class="section-divider section-divider--top" aria-hidden="true">
         <svg viewBox="0 0 1440 120" preserveAspectRatio="none" role="presentation" focusable="false">
-          <path fill="#FCF0F7" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
+          <path fill="#FFE3EC" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
         </svg>
       </div>
       <div class="services-preview">

--- a/style.css
+++ b/style.css
@@ -40,12 +40,7 @@ body {
   font-family: var(--ui-font);
   color: var(--text);
   line-height: 1.6;
-
-  /* Full-page gradient background */
-  background: linear-gradient(135deg, #FCF0F7 0%, #F7FCF0 45%, #F0F7FC 100%);
-  background-size: cover; /* Stretch to cover the viewport */
-  background-repeat: no-repeat; /* Prevent tiling */
-  background-attachment: fixed; /* Optional: Lock the gradient during scroll */
+  background: #f7f0f5;
 
   -webkit-font-smoothing: antialiased;
 }
@@ -127,6 +122,7 @@ button:focus-visible {
   width: 180px;
   height: auto;
   display: block;
+  object-fit: contain;
 }
 
 .header-divider {
@@ -193,6 +189,10 @@ button:focus-visible {
 .site-main {
   flex: 1;
   padding-top: var(--header-offset);
+  background: linear-gradient(135deg, #FFE3EC 0%, #E3FDFF 50%, #E3E3FF 100%);
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 .hero {
@@ -292,21 +292,9 @@ button:focus-visible {
   padding: calc(3.5rem + var(--divider-height)) 0 5.75rem;
   background-image: var(--services-glance-bg); /* Use background.png */
   background-size: cover;
-  background-position: center;
+  background-position: right center;
   background-repeat: no-repeat;
   background-color: #f7f0f5; /* Fallback color */
-}
-.services-glance-section::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: rgba(255, 255, 255, 0.62);
-  z-index: 0;
-}
-
-.services-glance-section > * {
-  position: relative;
-  z-index: 1;
 }
 
 /* Services split divider */


### PR DESCRIPTION
### Motivation
- Limit the pastel gradient to the top content (hero + intro) so the transition into the services section is seamless and non-repeating. 
- Ensure the scissors/background image in the Services at a Glance area remains visible and never tiles. 
- Scope frosted/glass effects to the intro card and service cards only, not the whole services background. 
- Keep header logo image consistent across pages and avoid layout shifts.

### Description
- Moved the page-wide gradient off `body` and applied the exact top gradient `linear-gradient(135deg, #FFE3EC 0%, #E3FDFF 50%, #E3E3FF 100%)` to `.site-main` with `background-size: cover`, `background-repeat: no-repeat`, and `background-position: center` in `style.css`.
- Removed the full-section overlay by deleting `.services-glance-section::before` and set the services section to use `background-image: var(--services-glance-bg)` with `background-position: right center`, `background-size: cover`, and `background-repeat: no-repeat` in `style.css` so `background.png` (scissors) remains visible.
- Adjusted the wave divider SVG fill in `index.html` to `#FFE3EC` so the divider visually matches the new top gradient boundary.
- Added `object-fit: contain` to `.logo-img` and updated `bookings.html` to use `InjoyBeauty.png` for consistent header logo display.

### Testing
- Started a local server with `python -m http.server` and navigated the site with a Playwright script to capture a full-page screenshot (`artifacts/injoy-home.png`), which completed successfully. 
- Verified visually that the hero/intro gradient is restricted to the top, the services background image is unobstructed and not tiled, and the wave blends with the top gradient. 
- No unit tests were present or run for these static CSS/HTML changes. 
- All automated steps completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69643bf69dc48322bd196395f1c03fc6)