### PR TITLE
Restrict frosted glass to intro card, reveal services background, update wave & logo

### DIFF
--- a/bookings.html
+++ b/bookings.html
@@ -33,7 +33,7 @@
     <div class="top-bar">
       <div class="logo-box">
         <a href="index.html" class="logo-link" aria-label="InJoy Beauty home">
-          <img src="InjoyBeauty.jpg" alt="InJoy Beauty logo" class="logo-img" width="160" height="80" />
+          <img src="InjoyBeauty.png" alt="InJoy Beauty logo" class="logo-img" width="160" height="80" />
         </a>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
     <section class="services-glance-section" aria-labelledby="services-preview-title" style="--services-glance-bg: url('background.png');">
       <div class="section-divider section-divider--top" aria-hidden="true">
         <svg viewBox="0 0 1440 120" preserveAspectRatio="none" role="presentation" focusable="false">
-          <path fill="#FCF0F7" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
+          <path fill="#FFE3EC" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
         </svg>
       </div>
       <div class="services-preview">

--- a/style.css
+++ b/style.css
@@ -40,12 +40,7 @@ body {
   font-family: var(--ui-font);
   color: var(--text);
   line-height: 1.6;
-
-  /* Full-page gradient background */
-  background: linear-gradient(135deg, #FCF0F7 0%, #F7FCF0 45%, #F0F7FC 100%);
-  background-size: cover; /* Stretch to cover the viewport */
-  background-repeat: no-repeat; /* Prevent tiling */
-  background-attachment: fixed; /* Optional: Lock the gradient during scroll */
+  background: #f7f0f5;
 
   -webkit-font-smoothing: antialiased;
 }
@@ -127,6 +122,7 @@ button:focus-visible {
   width: 180px;
   height: auto;
   display: block;
+  object-fit: contain;
 }
 
 .header-divider {
@@ -193,6 +189,10 @@ button:focus-visible {
 .site-main {
   flex: 1;
   padding-top: var(--header-offset);
+  background: linear-gradient(135deg, #FFE3EC 0%, #E3FDFF 50%, #E3E3FF 100%);
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 .hero {
@@ -201,6 +201,8 @@ button:focus-visible {
   padding: 3.5rem 1.25rem 2.5rem;
   display: grid;
   gap: 1.5rem;
+  background: transparent;
+  backdrop-filter: none;
 }
 
 .hero-content {
@@ -269,6 +271,8 @@ button:focus-visible {
   max-width: var(--section-max);
   margin: 0 auto;
   padding: 0 1.25rem 2.5rem;
+  background: transparent;
+  backdrop-filter: none;
 }
 
 .intro-card {
@@ -292,21 +296,9 @@ button:focus-visible {
   padding: calc(3.5rem + var(--divider-height)) 0 5.75rem;
   background-image: var(--services-glance-bg); /* Use background.png */
   background-size: cover;
-  background-position: center;
+  background-position: right center;
   background-repeat: no-repeat;
   background-color: #f7f0f5; /* Fallback color */
-}
-.services-glance-section::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: rgba(255, 255, 255, 0.62);
-  z-index: 0;
-}
-
-.services-glance-section > * {
-  position: relative;
-  z-index: 1;
 }
 
 /* Services split divider */


### PR DESCRIPTION
### Motivation
- Scope the frosted/glass blur to only the blurb container so the top half (hero and surrounding area) remains clear and non-frosted.
- Keep the pastel gradient limited to the top content area so the transition into the Services section is seamless.
- Ensure the Services "scissors" background image is visible and not covered by a full-section overlay.
- Make the header logo render consistently across pages.

### Description
- Applied the top gradient to `.site-main` with `background: linear-gradient(135deg, #FFE3EC 0%, #E3FDFF 50%, #E3E3FF 100%)` and removed the full-page `body` gradient.
- Removed the frosted overlay from the top half by setting `.hero` and `.intro-section` to `background: transparent` and `backdrop-filter: none`, while keeping the frosted effect on the actual blurb via `.intro-card { backdrop-filter: blur(8px); }`.
- Revealed the services background by using `background-image: var(--services-glance-bg)` on `.services-glance-section`, adjusted `background-position: right center`, and removed the `::before` overlay so `background.png` is visible and not tiled.
- Updated the divider SVG fill to `#FFE3EC` in `index.html`, added `object-fit: contain` to `.logo-img`, and switched the header logo to `InjoyBeauty.png` in `bookings.html` for consistent display.

### Testing
- Started a local static server with `python -m http.server` which ran successfully.
- Captured a full-page screenshot with a Playwright script (`artifacts/injoy-home.png`) to verify visual changes and the script completed successfully.
- No unit tests were present for these static HTML/CSS changes.
- All automated steps completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69643bf69dc48322bd196395f1c03fc6)