### PR TITLE
Add animated underline to primary nav links

### DIFF
--- a/style.css
+++ b/style.css
@@ -146,6 +146,7 @@ button:focus-visible {
   color: var(--text);
   padding: 0.35rem 0.25rem;
   border-radius: 6px;
+  position: relative;
 }
 
 .primary-nav a[aria-current="page"] {
@@ -154,6 +155,36 @@ button:focus-visible {
 
 .primary-nav a:hover {
   color: var(--brand);
+}
+
+.primary-nav a:focus-visible {
+  color: var(--brand);
+}
+
+.primary-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0.1rem;
+  height: 2px;
+  background: linear-gradient(90deg, #7a3c7a, #f7c7df);
+  border-radius: 999px;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.22s ease-out;
+}
+
+.primary-nav a:hover::after,
+.primary-nav a:focus-visible::after,
+.primary-nav a[aria-current="page"]::after {
+  transform: scaleX(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .primary-nav a::after {
+    transition: none;
+  }
 }
 
 .header-social {


### PR DESCRIPTION
### Motivation
- Provide a clean desktop/tablet navigation effect where each primary nav link shows a left-to-right animated underline on hover and focus while keeping mobile menu behavior unchanged.
- Keep the underline visually subtle, slightly below the text, rounded, and on-brand using brand tones.
- Ensure accessibility by applying the same behavior on `:focus-visible` and respecting `prefers-reduced-motion`.

### Description
- Added `position: relative` to `.primary-nav a` and created a `::after` pseudo-element placed `bottom: 0.1rem` with `height: 2px`, `border-radius: 999px`, and a `linear-gradient(90deg, #7a3c7a, #f7c7df)` background.
- Implemented animation using `transform: scaleX(0)` -> `scaleX(1)` with `transform-origin: left` and `transition: transform 0.22s ease-out`, triggered on `:hover`, `:focus-visible`, and `[aria-current="page"]`.
- Kept text color changes scoped to `.primary-nav a` by setting hover and `:focus-visible` text color to `var(--brand)` and preserving the active link color via `[aria-current="page"]`.
- Added `@media (prefers-reduced-motion: reduce)` to disable the underline transition when the user requests reduced motion.

### Testing
- No automated tests were executed for this static CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964484babe88322bfc7796942759316)