### PR TITLE
Frosted header on scroll, center footer, unify services layout, remove gallery password

### DIFF
--- a/about.html
+++ b/about.html
@@ -190,5 +190,18 @@
       </div>
     </div>
   </footer>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      const header = document.querySelector('.site-header');
+      if (!header) {
+        return;
+      }
+      const toggleHeader = function() {
+        header.classList.toggle('is-scrolled', window.scrollY > 10);
+      };
+      toggleHeader();
+      window.addEventListener('scroll', toggleHeader, { passive: true });
+    });
+  </script>
 </body>
 </html>

--- a/bookings.html
+++ b/bookings.html
@@ -187,10 +187,19 @@
   <script>
     // Client-side upload validation (PDF only, max 10MB). Replace or extend as needed.
     (function(){
+      const header = document.querySelector('.site-header');
       const uploadForm = document.getElementById('uploadForm');
       const fileInput = document.getElementById('completedPdf');
       const uploadError = document.getElementById('uploadError');
       const MAX_BYTES = 10 * 1024 * 1024; // 10MB
+
+      if (header) {
+        const toggleHeader = function() {
+          header.classList.toggle('is-scrolled', window.scrollY > 10);
+        };
+        toggleHeader();
+        window.addEventListener('scroll', toggleHeader, { passive: true });
+      }
 
       uploadForm.addEventListener('submit', function(e){
         uploadError.hidden = true;

--- a/gallery.html
+++ b/gallery.html
@@ -17,47 +17,9 @@
     .gallery-caption { margin-top:0.5rem; color:var(--muted); font-size:0.95rem; }
     .gallery-note { margin-top:1rem; color:var(--muted); }
 
-    /* Password modal / overlay */
-    .pw-overlay {
-      position: fixed;
-      inset: 0;
-      /* semi-transparent dim + blur the page behind the modal */
-      background: rgba(0,0,0,0.45);
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
-      will-change: backdrop-filter;
-      display: none; /* initial state hidden; script will show/hide explicitly */
-      align-items: center;
-      justify-content: center;
-      z-index: 9999;
-    }
-    /* Respect users who prefer reduced transparency/motion: disable blur */
-    @media (prefers-reduced-transparency: reduce), (prefers-reduced-motion: reduce) {
-      .pw-overlay {
-        backdrop-filter: none;
-        -webkit-backdrop-filter: none;
-        background: rgba(0,0,0,0.6); /* slightly darker fallback */
-      }
-    }
-
-    .pw-modal { background:#fff; padding:1.25rem; max-width:420px; width:92%; border-radius:8px; box-shadow:0 8px 32px rgba(0,0,0,0.3); }
-    .pw-modal h2{ margin:0 0 .5rem 0; font-family: "Playfair Display", serif; }
-    .pw-modal p{ margin:0 0 .75rem 0; color:var(--muted); }
-    .pw-input-row{ display:flex; gap:.5rem; }
-    .pw-input-row input[type="password"]{ flex:1; padding:.5rem .6rem; border-radius:6px; border:1px solid #ddd; }
-    .pw-input-row button{ padding:.5rem .75rem; border-radius:6px; border:none; background:var(--brand); color:#fff; }
-    .pw-error{ color:#b00020; margin-top:.5rem; }
-
     @media (max-width:1100px){ .gallery-grid{ grid-template-columns:repeat(2,1fr);} }
     @media (max-width:700px){ .gallery-grid{ grid-template-columns:1fr; } .gallery-item .placeholder{ height:160px; } }
   </style>
-
-  <!--
-    NOTE: This client-side password gate is only obfuscation and is NOT secure.
-    For real protection use server-side auth or GitHub Pages access controls.
-
-    To change the password: edit the GALLERY_PASSWORD constant in the script near the bottom.
-  -->
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to main content <span class="skip-icon" aria-hidden="true">↘</span></a>
@@ -153,107 +115,18 @@
     </div>
   </div>
 </footer>
-
-  <!-- Password overlay (client-side protection).
-       NOTE: overlay display is controlled by script to avoid CSS/hidden conflicts. -->
-  <div id="pwOverlay" class="pw-overlay" aria-hidden="true" style="display:none">
-    <div class="pw-modal" role="dialog" aria-modal="true" aria-labelledby="pwTitle">
-      <h2 id="pwTitle">This gallery is private</h2>
-      <p>Enter the password to view these photos.</p>
-      <div class="pw-input-row">
-        <input id="pwInput" type="password" aria-label="Gallery password" placeholder="Enter password">
-        <button id="pwSubmit">Enter</button>
-      </div>
-      <div id="pwError" class="pw-error" aria-live="polite"></div>
-    </div>
-  </div>
-
   <script>
-  (function(){
-    // CHANGE THIS to set the gallery password. Keep it a simple client-side gate.
-    // NOTE: this is client-side only and can be seen in the HTML/JS — not secure.
-    const GALLERY_PASSWORD = 'Molly2025';
-
-    const storageKey = 'injoy_gallery_unlocked_v1';
-    const overlay = document.getElementById('pwOverlay');
-    const pwInput = document.getElementById('pwInput');
-    const pwSubmit = document.getElementById('pwSubmit');
-    const pwError = document.getElementById('pwError');
-    const mainContent = document.getElementById('main-content');
-    const modal = overlay.querySelector('.pw-modal');
-
-    // helper: show/hide overlay and manage scroll / aria states
-    function unlockGallery(){
-      sessionStorage.setItem(storageKey, '1');
-      overlay.style.display = 'none';
-      overlay.setAttribute('aria-hidden', 'true');
-      document.body.style.overflow = '';
-      if(mainContent) mainContent.removeAttribute('aria-hidden');
-      pwError.textContent = '';
-    }
-    function lockGallery(){
-      overlay.style.display = 'flex';
-      overlay.setAttribute('aria-hidden','false');
-      document.body.style.overflow = 'hidden';
-      if(mainContent) mainContent.setAttribute('aria-hidden','true');
-      pwInput.value = '';
-      pwInput.focus();
-    }
-
-    // initialize overlay display based on sessionStorage
-    if(sessionStorage.getItem(storageKey) === '1'){
-      unlockGallery();
-    } else {
-      lockGallery();
-    }
-
-    // submit handler
-    pwSubmit.addEventListener('click', function(){
-      const val = (pwInput.value || '').trim();
-      if(val === GALLERY_PASSWORD){
-        unlockGallery();
-      } else {
-        pwError.textContent = 'Incorrect password — please try again.';
-        pwInput.value = '';
-        pwInput.focus();
+    document.addEventListener('DOMContentLoaded', function() {
+      const header = document.querySelector('.site-header');
+      if (!header) {
+        return;
       }
+      const toggleHeader = function() {
+        header.classList.toggle('is-scrolled', window.scrollY > 10);
+      };
+      toggleHeader();
+      window.addEventListener('scroll', toggleHeader, { passive: true });
     });
-
-    pwInput.addEventListener('keypress', function(e){
-      if(e.key === 'Enter') pwSubmit.click();
-    });
-
-    // trap Tab inside modal for keyboard users
-    const focusableSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-    function trapTab(e){
-      if(overlay.style.display === 'none') return;
-      if(e.key !== 'Tab') return;
-      const nodes = Array.from(modal.querySelectorAll(focusableSelector)).filter(n => !n.hasAttribute('disabled'));
-      if(nodes.length === 0){ e.preventDefault(); return; }
-      const first = nodes[0], last = nodes[nodes.length -1];
-      if(e.shiftKey && document.activeElement === first){ e.preventDefault(); last.focus(); }
-      else if(!e.shiftKey && document.activeElement === last){ e.preventDefault(); first.focus(); }
-    }
-    document.addEventListener('keydown', trapTab);
-
-    // keep focus inside modal when locked
-    document.addEventListener('focus', function(e){
-      if(overlay.style.display !== 'none' && !overlay.contains(e.target)){
-        e.stopPropagation();
-        pwInput.focus();
-      }
-    }, true);
-
-    // small convenience: allow Esc to clear input or relock (if unlocked, does nothing)
-    document.addEventListener('keydown', function(e){
-      if(e.key === 'Escape' && overlay.style.display !== 'none'){
-        pwInput.value = '';
-        pwError.textContent = '';
-        pwInput.focus();
-      }
-    });
-
-  })();
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     document.addEventListener('DOMContentLoaded', function() {
       const hamburger = document.querySelector('.hamburger-btn');
       const mobileMenu = document.querySelector('.mobile-menu');
+      const header = document.querySelector('.site-header');
       
       if (hamburger && mobileMenu) {
         hamburger.addEventListener('click', function() {
@@ -23,6 +24,14 @@
           hamburger.setAttribute('aria-expanded', !isExpanded);
           mobileMenu.classList.toggle('active');
         });
+      }
+
+      if (header) {
+        const toggleHeader = function() {
+          header.classList.toggle('is-scrolled', window.scrollY > 10);
+        };
+        toggleHeader();
+        window.addEventListener('scroll', toggleHeader, { passive: true });
       }
     });
   </script>

--- a/services.html
+++ b/services.html
@@ -47,50 +47,54 @@
   </header>
 
   <main id="main-content" class="site-main services-page" role="main" tabindex="-1">
-    <section class="services-intro" aria-labelledby="services-heading">
-      <div class="services-intro-card">
-        <h1 id="services-heading">Service Menu</h1>
-        <p class="services-intro-text">
-          I offer a welcoming, sensory-friendly approach. If you need accommodations such as extra time, a quiet space, or a mobile visit, please let me know.
-        </p>
+    <div class="services-menu-shell">
+      <div class="services-menu-block">
+        <section class="services-intro" aria-labelledby="services-heading">
+          <div class="services-intro-card">
+            <h1 id="services-heading">Service Menu</h1>
+            <p class="services-intro-text">
+              I offer a welcoming, sensory-friendly approach. If you need accommodations such as extra time, a quiet space, or a mobile visit, please let me know.
+            </p>
+          </div>
+        </section>
+
+        <section class="services-listing" aria-label="Service offerings">
+          <div class="services-listing-card">
+            <div class="services-grid">
+              <article class="service-card" aria-labelledby="hair-services-heading">
+                <div class="service-accent" aria-hidden="true"></div>
+                <h2 id="hair-services-heading">Hair Services</h2>
+                <ul class="service-list">
+                  <li>Haircuts for men, women, and children</li>
+                  <li>Hair coloring & touch-ups</li>
+                  <li>Simple styling and trims</li>
+                </ul>
+              </article>
+
+              <article class="service-card" aria-labelledby="facial-body-heading">
+                <div class="service-accent" aria-hidden="true"></div>
+                <h2 id="facial-body-heading">Facial & Body Hair</h2>
+                <ul class="service-list">
+                  <li>Beard trimming & shaving</li>
+                  <li>Leg waxing or shaving</li>
+                  <li>Gentle facial waxing</li>
+                </ul>
+              </article>
+
+              <article class="service-card" aria-labelledby="nail-care-heading">
+                <div class="service-accent" aria-hidden="true"></div>
+                <h2 id="nail-care-heading">Nail Care</h2>
+                <ul class="service-list">
+                  <li>Nail trimming & shaping</li>
+                  <li>Hand & foot care</li>
+                  <li>Nail painting & polish changes</li>
+                </ul>
+              </article>
+            </div>
+          </div>
+        </section>
       </div>
-    </section>
-
-    <section class="services-listing" aria-label="Service offerings">
-      <div class="services-listing-card">
-        <div class="services-grid">
-          <article class="service-card" aria-labelledby="hair-services-heading">
-            <div class="service-accent" aria-hidden="true"></div>
-            <h2 id="hair-services-heading">Hair Services</h2>
-            <ul class="service-list">
-              <li>Haircuts for men, women, and children</li>
-              <li>Hair coloring & touch-ups</li>
-              <li>Simple styling and trims</li>
-            </ul>
-          </article>
-
-          <article class="service-card" aria-labelledby="facial-body-heading">
-            <div class="service-accent" aria-hidden="true"></div>
-            <h2 id="facial-body-heading">Facial & Body Hair</h2>
-            <ul class="service-list">
-              <li>Beard trimming & shaving</li>
-              <li>Leg waxing or shaving</li>
-              <li>Gentle facial waxing</li>
-            </ul>
-          </article>
-
-          <article class="service-card" aria-labelledby="nail-care-heading">
-            <div class="service-accent" aria-hidden="true"></div>
-            <h2 id="nail-care-heading">Nail Care</h2>
-            <ul class="service-list">
-              <li>Nail trimming & shaping</li>
-              <li>Hand & foot care</li>
-              <li>Nail painting & polish changes</li>
-            </ul>
-          </article>
-        </div>
-      </div>
-    </section>
+    </div>
 
     <section class="services-note" aria-label="Service details">
       <div class="services-note-card">
@@ -103,7 +107,7 @@
     </section>
   </main>
 
- <footer class="site-footer" role="contentinfo" aria-label="Site footer">
+  <footer class="site-footer" role="contentinfo" aria-label="Site footer">
     <div class="footer-inner">
       <div class="footer-brand" aria-label="Brand and copyright">
         <img src="InjoyOGsmall.jpg" alt="InJoy Beauty logo" class="footer-photo">
@@ -117,5 +121,18 @@
       </div>
     </div>
   </footer>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      const header = document.querySelector('.site-header');
+      if (!header) {
+        return;
+      }
+      const toggleHeader = function() {
+        header.classList.toggle('is-scrolled', window.scrollY > 10);
+      };
+      toggleHeader();
+      window.addEventListener('scroll', toggleHeader, { passive: true });
+    });
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -100,6 +100,16 @@ button:focus-visible {
   width: 100%;
   z-index: 999;
   background: transparent;
+  transition: background 0.25s ease, backdrop-filter 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+  border-bottom: 1px solid transparent;
+}
+
+.site-header.is-scrolled {
+  background: rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-bottom-color: rgba(255, 255, 255, 0.35);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.06);
 }
 
 .top-bar {
@@ -374,13 +384,35 @@ button:focus-visible {
   padding-top: 1.5rem;
 }
 
-.services-intro-card {
-  background: linear-gradient(135deg, rgba(255, 248, 245, 0.92), rgba(246, 250, 244, 0.9));
-  border-radius: 24px;
-  padding: 2.25rem;
-  border: 1px solid rgba(255, 255, 255, 0.7);
+.services-menu-shell {
+  max-width: var(--section-max);
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem 2.5rem;
+}
+
+.services-menu-block {
+  background: linear-gradient(150deg, rgba(255, 250, 247, 0.9), rgba(244, 250, 248, 0.9));
+  border-radius: 30px;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.75);
   box-shadow: 0 18px 45px rgba(0, 0, 0, 0.06);
-  backdrop-filter: blur(10px);
+  display: grid;
+  gap: 1.75rem;
+}
+
+.services-menu-block .services-intro,
+.services-menu-block .services-listing {
+  padding: 0;
+  margin: 0;
+}
+
+.services-intro-card {
+  background: transparent;
+  border-radius: 0;
+  padding: 0;
+  border: none;
+  box-shadow: none;
+  backdrop-filter: none;
 }
 
 .services-intro-card h1 {
@@ -399,11 +431,11 @@ button:focus-visible {
 }
 
 .services-listing-card {
-  background: linear-gradient(160deg, rgba(255, 255, 255, 0.85), rgba(248, 244, 239, 0.9));
-  border-radius: 28px;
-  padding: 1.6rem;
-  border: 1px solid rgba(255, 255, 255, 0.75);
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.05);
+  background: transparent;
+  border-radius: 0;
+  padding: 0;
+  border: none;
+  box-shadow: none;
 }
 
 .service-card {
@@ -419,7 +451,7 @@ button:focus-visible {
   margin: 0 0 0.6rem 0;
   font-family: "Playfair Display", serif;
   color: var(--brand);
-  font-size: 1.25rem;
+  font-size: 2.25rem;
 }
 
 .service-accent {
@@ -495,6 +527,9 @@ button:focus-visible {
 .footer-inner {
   max-width: var(--max-width);
   margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  text-align: center;
 }
 
 .footer-brand {
@@ -502,6 +537,7 @@ button:focus-visible {
   align-items: center;
   gap: 1rem;
   flex-wrap: wrap;
+  justify-content: center;
 }
 
 .footer-photo {
@@ -515,6 +551,7 @@ button:focus-visible {
 .footer-copy {
   display: grid;
   gap: 0.2rem;
+  text-align: center;
 }
 
 .brand-title {


### PR DESCRIPTION
### Motivation
- Improve header readability when it overlaps page content while keeping it transparent at the top.
- Ensure footer content is centered and visually consistent across all pages.
- Visually group the Services intro and cards into a single outer block while keeping each service card separate, and increase the three service category headings by +1 unit in their existing unit.
- Make the gallery publicly visible by removing the client-side password gate.

### Description
- Added a scroll state class `.is-scrolled` and transitions in `style.css` to apply `background: rgba(255,255,255,0.55)`, `backdrop-filter: blur(10px)`, a thin border-bottom, and a subtle shadow, and wired a small scroll toggle script into the pages (`index.html`, `services.html`, `about.html`, `bookings.html`, `gallery.html`) to add/remove `.is-scrolled` when `window.scrollY > 10`.
- Centered footer layout by adjusting `.footer-inner`, `.footer-brand`, and `.footer-copy` in `style.css` so the footer is horizontally centered on desktop and mobile while preserving all existing copy.
- Wrapped the Services intro and the services cards inside a shared wrapper (`.services-menu-shell` / `.services-menu-block`) in `services.html` and `style.css`, keeping individual `.service-card` elements intact, and increased the service card headings from `1.25rem` to `2.25rem` to satisfy the +1 unit requirement.
- Removed the gallery password overlay and all related CSS/JS from `gallery.html` so the gallery content renders immediately on page load.

### Testing
- Started a local static server with `python -m http.server 8000` to serve the site and it launched successfully.
- Attempted an automated visual check with Playwright to capture screenshots, but the headless browser crashed in this environment and the Playwright run failed.
- No unit tests exist for these static HTML/CSS/JS changes, so no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966801adaa483229f35e348ec1c30ba)