### PR TITLE
Align booking headers to gallery font and revamp Gallery into wave-separated frosted-card layout

### DIFF
--- a/bookings.html
+++ b/bookings.html
@@ -70,7 +70,7 @@
   <main id="main-content" class="site-main" role="main" tabindex="-1">
     <section class="bookings-layout" aria-label="Booking information">
       <div class="bookings-card">
-        <h1 id="bookings-heading" class="bookings-title">Book Your Appointment</h1>
+        <h1 id="bookings-heading" class="bookings-title display-title">Book Your Appointment</h1>
 
         <p class="bookings-sub">
           I offer flexible booking to meet your comfort level and needs.
@@ -84,7 +84,7 @@
       </div>
 
       <div class="booking-card" role="region" aria-label="Booking and intake form">
-        <h2 style="margin-top:0; font-size:1.5rem;">Booking & Intake</h2>
+        <h2 class="display-title" style="margin-top:0; font-size:1.5rem;">Booking & Intake</h2>
         <p class="note">You can preview the intake form below, download it to fill offline, then upload the completed PDF here. If you prefer, use the HTML booking request form on this page to submit your appointment request.</p>
 
         <div class="preview-wrap" aria-live="polite">
@@ -101,7 +101,7 @@
 
           <!-- RIGHT: download + upload controls -->
           <aside class="side-col" aria-label="Download and upload completed intake form">
-            <h2 style="margin-top:0.1rem;font-size:1.05rem;">Download & Upload</h2>
+            <h2 class="display-title" style="margin-top:0.1rem;font-size:1.05rem;">Download & Upload</h2>
 
             <p class="note">If your browser doesn't allow filling PDFs inline, download the file, fill it in your PDF app, then upload the completed file below.</p>
 
@@ -134,7 +134,7 @@
 
         <!-- Optional: a short HTML booking request form (structured fields) -->
         <div style="margin-top:1rem;">
-          <h2 style="margin:0 0 .5rem 0;">Quick booking request (optional)</h2>
+          <h2 class="display-title" style="margin:0 0 .5rem 0;">Quick booking request (optional)</h2>
           <p class="note">If you'd rather request a booking without the full intake, use this short form and we'll follow up for the details.</p>
 
           <form id="bookingRequest" method="POST" action="https://formspree.io/f/yourFormID" style="display:grid;grid-template-columns:1fr 1fr;gap:.5rem;">

--- a/gallery.html
+++ b/gallery.html
@@ -6,22 +6,8 @@
   <title>A Look Inside — InJoy Beauty (Gallery)</title>
   <link rel="stylesheet" href="style.css" />
 
-  <!-- Gallery page scoped styles -->
-  <style>
-    /* small, self-contained gallery styles */
-    .gallery-hero { max-width: var(--max-width); margin: 1.5rem auto; padding: 1rem; }
-    .gallery-card { background: rgba(255,255,255,0.92); border-radius:10px; padding:1rem; box-shadow:0 8px 24px rgba(0,0,0,0.04); position:relative; z-index:2; }
-    .gallery-grid { display:grid; grid-template-columns: repeat(3,1fr); gap:1rem; margin-top:1rem; }
-    .gallery-item { background: #f7f7f7; border-radius:8px; min-height:160px; display:flex; align-items:center; justify-content:center; flex-direction:column; padding:1rem; }
-    .gallery-item .placeholder { width:100%; height:120px; background: linear-gradient(135deg,#eee,#f6f6f6); border-radius:6px; display:flex; align-items:center; justify-content:center; color:var(--muted); font-weight:600; text-align:center; padding:0 .5rem; }
-    .gallery-caption { margin-top:0.5rem; color:var(--muted); font-size:0.95rem; }
-    .gallery-note { margin-top:1rem; color:var(--muted); }
-
-    @media (max-width:1100px){ .gallery-grid{ grid-template-columns:repeat(2,1fr);} }
-    @media (max-width:700px){ .gallery-grid{ grid-template-columns:1fr; } .gallery-item .placeholder{ height:160px; } }
-  </style>
 </head>
-<body>
+<body class="gallery-page">
   <a class="skip-link" href="#main-content">Skip to main content <span class="skip-icon" aria-hidden="true">↘</span></a>
 
   <header class="site-header" role="banner">
@@ -57,45 +43,137 @@
 
   <main id="main-content" class="site-main" role="main" tabindex="-1">
     <section class="gallery-hero" aria-labelledby="gallery-heading">
-      <div class="gallery-card">
-        <h1 id="gallery-heading" style="margin-top:0; font-family:Playfair Display, serif;">A Look Inside InJoy Beauty</h1>
+      <div class="gallery-hero-card">
+        <h1 id="gallery-heading" class="display-title" style="margin-top:0;">A Look Inside InJoy Beauty</h1>
         <p class="gallery-note"><strong>Note:</strong> This will have to wait until next year when I move into a new place — for now I offer only mobile services.</p>
         <p class="gallery-note">Step inside my sensory-friendly home salon — a calm, welcoming space designed for comfort and accessibility. Here, beauty is about feeling good, not just looking good.</p>
+        <p class="gallery-note" style="margin-top:1.25rem;">Photos will be added soon — check back later.</p>
+      </div>
+    </section>
 
-        <div class="gallery-grid" aria-live="polite">
-          <!-- Placeholder items for future photos -->
-          <figure class="gallery-item" role="group" aria-label="Salon setup — coming soon">
-            <div class="placeholder" role="img" aria-label="Salon setup placeholder">Salon setup — coming soon</div>
-            <figcaption class="gallery-caption">Salon setup (wheelchair accessible)</figcaption>
+    <section class="gallery-section" aria-labelledby="hair-services-title">
+      <div class="section-divider" aria-hidden="true">
+        <svg viewBox="0 0 1440 120" preserveAspectRatio="none" role="presentation" focusable="false">
+          <path fill="#FFE3EC" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
+        </svg>
+      </div>
+      <div class="gallery-section-inner">
+        <h2 id="hair-services-title" class="section-title display-title">Hair Services</h2>
+        <p class="gallery-blurb">(Write-up goes here…)</p>
+
+        <div class="gallery-columns">
+          <div class="gallery-column">
+            <h3 class="display-title">Men</h3>
+            <div class="gallery-column-grid">
+              <figure class="frosted-card">
+                <div class="photo-slot">
+                  <img class="gallery-photo" src="https://placehold.co/400x500?text=Men+Hair+1" alt="Men's hair service placeholder">
+                </div>
+              </figure>
+              <figure class="frosted-card">
+                <div class="photo-slot">
+                  <img class="gallery-photo" src="https://placehold.co/400x500?text=Men+Hair+2" alt="Men's hair service placeholder">
+                </div>
+              </figure>
+            </div>
+          </div>
+
+          <div class="gallery-column">
+            <h3 class="display-title">Women</h3>
+            <div class="gallery-column-grid">
+              <figure class="frosted-card">
+                <div class="photo-slot">
+                  <img class="gallery-photo" src="https://placehold.co/400x500?text=Women+Hair+1" alt="Women's hair service placeholder">
+                </div>
+              </figure>
+              <figure class="frosted-card">
+                <div class="photo-slot">
+                  <img class="gallery-photo" src="https://placehold.co/400x500?text=Women+Hair+2" alt="Women's hair service placeholder">
+                </div>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="gallery-section" aria-labelledby="nail-care-title">
+      <div class="section-divider" aria-hidden="true">
+        <svg viewBox="0 0 1440 120" preserveAspectRatio="none" role="presentation" focusable="false">
+          <path fill="#FFE3EC" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
+        </svg>
+      </div>
+      <div class="gallery-section-inner">
+        <h2 id="nail-care-title" class="section-title display-title">Nail Care</h2>
+        <p class="gallery-blurb">(Write-up goes here…)</p>
+
+        <div class="gallery-grid">
+          <figure class="frosted-card">
+            <div class="photo-slot">
+              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+1" alt="Nail care placeholder">
+            </div>
           </figure>
-
-          <figure class="gallery-item" role="group" aria-label="Soft lighting placeholder">
-            <div class="placeholder" role="img" aria-label="Soft lighting placeholder">Soft lighting — coming soon</div>
-            <figcaption class="gallery-caption">Soft lighting & calming colors</figcaption>
+          <figure class="frosted-card">
+            <div class="photo-slot">
+              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+2" alt="Nail care placeholder">
+            </div>
           </figure>
-
-          <figure class="gallery-item" role="group" aria-label="Before and after placeholder">
-            <div class="placeholder" role="img" aria-label="Before and after placeholder">Before / After — coming soon</div>
-            <figcaption class="gallery-caption">Before & after (with permission)</figcaption>
+          <figure class="frosted-card">
+            <div class="photo-slot">
+              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+3" alt="Nail care placeholder">
+            </div>
           </figure>
-
-          <figure class="gallery-item" role="group" aria-label="Smiling clients placeholder">
-            <div class="placeholder" role="img" aria-label="Smiling clients placeholder">Smiling clients — coming soon</div>
-            <figcaption class="gallery-caption">Smiling clients & cozy atmosphere</figcaption>
+          <figure class="frosted-card">
+            <div class="photo-slot">
+              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+4" alt="Nail care placeholder">
+            </div>
           </figure>
-
-          <figure class="gallery-item" role="group" aria-label="Cozy atmosphere placeholder">
-            <div class="placeholder" role="img" aria-label="Cozy atmosphere placeholder">Cozy atmosphere — coming soon</div>
-            <figcaption class="gallery-caption">Gentle care & calm spaces</figcaption>
+          <figure class="frosted-card">
+            <div class="photo-slot">
+              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+5" alt="Nail care placeholder">
+            </div>
           </figure>
-
-          <figure class="gallery-item" role="group" aria-label="Mobile services placeholder">
-            <div class="placeholder" role="img" aria-label="Mobile services placeholder">Mobile services — coming soon</div>
-            <figcaption class="gallery-caption">Mobile services available</figcaption>
+          <figure class="frosted-card">
+            <div class="photo-slot">
+              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+6" alt="Nail care placeholder">
+            </div>
           </figure>
         </div>
+      </div>
+    </section>
 
-        <p class="gallery-note" style="margin-top:1.25rem;">Photos will be added soon — check back later.</p>
+    <section class="gallery-section" aria-labelledby="extras-title">
+      <div class="section-divider" aria-hidden="true">
+        <svg viewBox="0 0 1440 120" preserveAspectRatio="none" role="presentation" focusable="false">
+          <path fill="#FFE3EC" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
+        </svg>
+      </div>
+      <div class="gallery-section-inner">
+        <h2 id="extras-title" class="section-title display-title">Extras</h2>
+        <p class="gallery-blurb">(Write-up goes here…)</p>
+
+        <div class="gallery-grid">
+          <figure class="frosted-card">
+            <div class="photo-slot">
+              <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+1" alt="Extras placeholder">
+            </div>
+          </figure>
+          <figure class="frosted-card">
+            <div class="photo-slot">
+              <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+2" alt="Extras placeholder">
+            </div>
+          </figure>
+          <figure class="frosted-card">
+            <div class="photo-slot">
+              <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+3" alt="Extras placeholder">
+            </div>
+          </figure>
+          <figure class="frosted-card">
+            <div class="photo-slot">
+              <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+4" alt="Extras placeholder">
+            </div>
+          </figure>
+        </div>
       </div>
     </section>
   </main>

--- a/style.css
+++ b/style.css
@@ -45,6 +45,10 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+.display-title {
+  font-family: "Playfair Display", serif;
+}
+
 img {
   max-width: 100%;
   height: auto;
@@ -370,6 +374,131 @@ button:focus-visible {
   font-family: "Playfair Display", serif;
   color: var(--brand);
   font-size: clamp(2.2rem, 4vw, 3.4rem);
+}
+
+/* Gallery layout */
+.gallery-page .gallery-hero {
+  max-width: var(--max-width);
+  margin: 1.75rem auto 0;
+  padding: 1rem 1.25rem 0;
+}
+
+.gallery-page .gallery-hero-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+}
+
+.gallery-page .gallery-note {
+  margin-top: 0.75rem;
+  color: var(--muted);
+}
+
+.gallery-page .gallery-section {
+  position: relative;
+  --divider-height: clamp(70px, 12vw, 130px);
+  padding: calc(3.25rem + var(--divider-height)) 0 3.5rem;
+  background: #f7f0f5;
+}
+
+.gallery-page .gallery-section:nth-of-type(even) {
+  background: #f5ecf3;
+}
+
+.gallery-page .gallery-section-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.25rem;
+}
+
+.gallery-page .section-title {
+  margin: 0 0 0.5rem;
+  color: var(--brand);
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+}
+
+.gallery-page .gallery-blurb {
+  margin: 0 0 1.75rem;
+  color: var(--muted);
+}
+
+.gallery-page .frosted-card {
+  position: relative;
+  border-radius: 18px;
+  overflow: hidden;
+  padding: 0.75rem;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
+}
+
+.gallery-page .frosted-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  z-index: 0;
+}
+
+.gallery-page .frosted-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.gallery-page .photo-slot {
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #f0f0f0;
+}
+
+.gallery-page .gallery-photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-page .gallery-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2rem;
+}
+
+.gallery-page .gallery-column h3 {
+  margin: 0 0 1rem;
+  font-size: 1.4rem;
+  color: var(--brand);
+}
+
+.gallery-page .gallery-column-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.gallery-page .gallery-column-grid .frosted-card:nth-child(2) {
+  margin-top: 1.25rem;
+}
+
+.gallery-page .gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+@media (max-width: 900px) {
+  .gallery-page .gallery-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 700px) {
+  .gallery-page .gallery-section {
+    padding: calc(2.75rem + var(--divider-height)) 0 3rem;
+  }
 }
 
 .services-intro,


### PR DESCRIPTION
### Motivation
- Ensure header typography is consistent between the Gallery title and the Book Now page for a unified brand look. 
- Make the Gallery page more inviting and scalable to many photos by organizing content into service sections with the same wave-style separators used on the homepage. 
- Provide a reusable, layered frosted-card photo component so images remain crisp while preserving the site’s soft aesthetic. 

### Description
- Added a shared display class `display-title` (uses `Playfair Display`) in `style.css` and applied it to the Gallery title and Book Now headers to unify font styling across pages. 
- Rebuilt `gallery.html` into three wave-separated sections — `Hair Services`, `Nail Care`, and `Extras` — each with a section title using the `display-title` class and minimal placeholder blurbs. 
- Implemented `.frosted-card` with a `::before` frosted layer behind content, plus `.photo-slot` and `.gallery-photo` for fixed aspect-ratio image slots using `object-fit: cover` and consistent spacing. 
- Implemented the Hair Services layout with two columns (`Men` and `Women`) that show exactly two photos per column and a staggered vertical layout via a top margin on second items, and added responsive grids for Nail Care and Extras; modified files: `gallery.html`, `bookings.html`, and `style.css`. 

### Testing
- Served the site locally with `python -m http.server 8000` and loaded `gallery.html` to confirm layout and assets render without console errors. 
- Captured a full-page screenshot of `gallery.html` using a Playwright script to visually verify the wave separators, section titles, frosted cards, and image placeholders (succeeded). 
- No automated unit tests were present or run beyond the visual smoke test described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696696d4d0588322bb7220a75e735c5b)