### PR TITLE
Make site footer transparent

### DIFF
--- a/style.css
+++ b/style.css
@@ -651,12 +651,12 @@ button:focus-visible {
 .site-footer {
   padding: 1rem 1.25rem 1.35rem;
   color: var(--muted);
-  background: rgba(255, 255, 255, 0.45);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-top: 1px solid rgba(255, 255, 255, 0.35);
-  box-shadow: 0 -10px 24px rgba(0, 0, 0, 0.04);
-  transition: background 0.25s ease, backdrop-filter 0.25s ease, border-color 0.25s ease;
+  background: transparent;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border-top: none;
+  box-shadow: none;
+  transition: color 0.25s ease;
 }
 
 .footer-inner {


### PR DESCRIPTION
### Motivation
- The footer should be fully transparent for a cleaner overlay look and to match the requested design change. 
- Remove visual chrome (blur, border, and shadow) so the page background shows through the footer. 

### Description
- Updated `style.css` to change the `.site-footer` rules to `background: transparent` and remove the translucent background. 
- Disabled `backdrop-filter` and `-webkit-backdrop-filter` by setting them to `none` and removed the `border-top` and `box-shadow`. 
- Replaced the `transition` on background/filters with a `color` transition to avoid animating removed properties. 

### Testing
- Launched a local static server with `python -m http.server 8000` and attempted an automated Playwright screenshot for verification, but Chromium crashed with a SIGSEGV so visual confirmation could not be captured. 
- No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696699df6118832287c6ed1c4f0fec6c)