### PR TITLE
Adjust social icons, intro/about justification, and services transparency/layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -60,6 +60,7 @@
       color: var(--brand);
       font-size: clamp(1.6rem, 4.6vw, 2.6rem);
       line-height: 1.02;
+      grid-column: 1 / -1;
     }
 
     .about-paragraph {
@@ -69,6 +70,7 @@
       font-size: 1rem;
       line-height: 1.55;
       max-width: 68ch;
+      text-align: justify;
     }
 
     .why-list {
@@ -142,6 +144,7 @@
   <main id="main-content" class="site-main" role="main" tabindex="-1">
     <section class="about-hero" aria-labelledby="about-heading">
       <div class="about-card" role="region" aria-labelledby="about-heading" aria-describedby="about-desc">
+        <h1 id="about-heading" class="about-title">Meet Jaymie!</h1>
         <!-- Photo placeholder: replace 'jaymie.jpg' with your photo filename -->
         <div class="about-photo" aria-hidden="false">
           <figure>
@@ -152,8 +155,6 @@
 
         <!-- Text content -->
         <div class="about-body">
-          <h1 id="about-heading" class="about-title">Meet Jaymie!</h1>
-
           <div id="about-desc" class="about-text">
             <p class="about-paragraph"><strong>Hello! My name is Jaymie Law, and I’m the proud owner of InJoy Beauty.</strong></p>
 

--- a/style.css
+++ b/style.css
@@ -209,8 +209,8 @@ button:focus-visible {
 }
 
 .social-btn {
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
   border-radius: 999px;
   display: inline-flex;
   align-items: center;
@@ -227,8 +227,8 @@ button:focus-visible {
 }
 
 .social-icon {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
 }
 
 .site-main {
@@ -321,7 +321,7 @@ button:focus-visible {
 }
 
 .intro-card {
-  background: var(--card-bg);
+  background: rgba(255, 255, 255, 0.6);
   border: 1px solid var(--card-border);
   border-radius: 24px;
   padding: 2rem;
@@ -333,6 +333,7 @@ button:focus-visible {
   margin: 0 0 1rem 0;
   font-size: 1.02rem;
   color: var(--text);
+  text-align: justify;
 }
 
 .services-glance-section {
@@ -520,7 +521,7 @@ button:focus-visible {
 }
 
 .services-menu-block {
-  background: linear-gradient(150deg, rgba(255, 250, 247, 0.9), rgba(244, 250, 248, 0.9));
+  background: transparent;
   border-radius: 30px;
   padding: 2rem;
   border: 1px solid rgba(255, 255, 255, 0.75);
@@ -599,7 +600,7 @@ button:focus-visible {
 }
 
 .services-note-card {
-  background: linear-gradient(140deg, rgba(255, 252, 250, 0.95), rgba(241, 246, 240, 0.9));
+  background: linear-gradient(140deg, rgba(255, 252, 250, 0.6), rgba(241, 246, 240, 0.55));
   border-radius: 22px;
   padding: 1.6rem;
   border: 1px solid rgba(232, 226, 219, 0.7);
@@ -622,6 +623,10 @@ button:focus-visible {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1rem;
+}
+
+#facial-body-heading {
+  white-space: nowrap;
 }
 
 @media (max-width: 320px) {


### PR DESCRIPTION
### Motivation
- Slightly increase social icon/button size site-wide for improved tap targets and visual balance.
- Make the homepage intro card and services note card more transparent while keeping content readable.
- Improve text flow by justifying the homepage intro paragraph and About page body paragraphs.
- Reorder the About layout so the “Meet Jaymie!” heading appears above the photo and prevent wrapping of the “Facial & Body Hair” heading.

### Description
- Updated `style.css` to scale up `.social-btn` to `40px` and `.social-icon` to `20px`, and added `text-align: justify` to `.intro-text` and `.about-paragraph` for justified body copy.
- Reduced intro card opacity by changing `.intro-card` background to `rgba(255,255,255,0.6)` and softened the services note background by lowering gradient alpha in `.services-note-card`.
- Removed the filled background on the services container by setting `.services-menu-block` background to `transparent` and added `#facial-body-heading { white-space: nowrap; }` to keep the heading on one line.
- Modified `about.html` to move the `<h1 id="about-heading">Meet Jaymie!</h1>` above the photo and added `grid-column: 1 / -1` to `.about-title` to ensure proper layout.

### Testing
- Launched a local HTTP server with `python -m http.server` and used a Playwright script to load and capture screenshots of `index.html`, `about.html`, and `services.html`, which completed successfully.
- Visual inspection of the generated screenshots confirmed the social buttons are larger, intro/about paragraphs are justified, the About heading appears above the photo, and services card transparency/layout changes are applied.
- No automated unit tests were applicable to these static HTML/CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a073fc54832288696798317ae355)