### PR TITLE
Fix header/hero overlap on narrow mobile viewports (≤420px / ≤380px)

### DIFF
--- a/style.css
+++ b/style.css
@@ -898,6 +898,62 @@ button:focus-visible {
   }
 }
 
+@media (max-width: 420px) {
+  .top-bar {
+    flex-wrap: wrap;
+    row-gap: 0.65rem;
+    align-items: center;
+  }
+  .logo-box {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .hamburger-btn {
+    margin-left: auto;
+  }
+  .header-social {
+    order: 4;
+    width: 100%;
+    justify-content: flex-start;
+  }
+  .site-main {
+    padding-top: 116px;
+  }
+  .hero {
+    padding-top: 2.2rem;
+  }
+  .hero-title {
+    font-size: clamp(2.2rem, 9vw, 3.1rem);
+    line-height: 1.05;
+    margin-bottom: 0.35rem;
+  }
+  .hero-subtitle {
+    font-size: 1rem;
+    margin-bottom: 1.1rem;
+  }
+}
+
+@media (max-width: 380px) {
+  .site-main {
+    padding-top: 126px;
+  }
+  .hero {
+    padding-top: 2rem;
+  }
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .hero-actions a {
+    justify-content: center;
+    width: 100%;
+  }
+  .btn-primary,
+  .btn-secondary {
+    padding: 0.7rem 1.25rem;
+  }
+}
+
 /* Footer responsive */
 @media (max-width: 700px) {
   .footer-inner {


### PR DESCRIPTION
### Motivation
- Narrow phones (≈360×780 CSS px, e.g. Galaxy S24) showed the header top-bar wrapping into multiple rows while the hero used a smaller top offset, causing social icons to overlap the script heading and collapsing spacing.

### Description
- Added two mobile breakpoints: `@media (max-width: 420px)` and `@media (max-width: 380px)` in `style.css` to handle narrow layouts without changing desktop/tablet behavior.
- Ensured header stacks reliably by allowing `.top-bar` to wrap, moving `.header-social` to its own row (`order: 4; width: 100%; justify-content: flex-start;`), and making `.logo-box` flexible so items don’t overlap.
- Increased `--site-main` top padding at small widths to match the taller wrapped header and tightened `.hero-title` sizing/`line-height` to prevent collisions.
- Made CTA layout adaptive by stacking `.hero-actions` vertically at `≤380px` and making buttons stretch to full width with reduced padding so labels don’t squish.

### Testing
- Ran visual smoke checks by serving the site locally and capturing screenshots with Playwright at `360×780`, `390×844`, and `412×915`; screenshots were produced and reviewed showing the header/social icons do not overlap the hero text.
- No automated unit tests were required or modified; the CSS change was validated with the three viewport screenshots which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966f6d672ac832280c0d0882b72963f)