### PR TITLE
Use clamp() for Services at a Glance background-size

### DIFF
--- a/style.css
+++ b/style.css
@@ -341,7 +341,7 @@ button:focus-visible {
   --divider-height: clamp(70px, 12vw, 130px);
   padding: calc(3.5rem + var(--divider-height)) 0 5.75rem;
   background-image: var(--services-glance-bg); /* Use background.png */
-  background-size: cover;
+  background-size: clamp(320px, 60vw, 900px) auto;
   background-position: right center;
   background-repeat: no-repeat;
   background-color: #f7f0f5; /* Fallback color */


### PR DESCRIPTION
### Motivation
- The artwork in the `Services at a Glance` section felt overly zoomed with `background-size: cover`, hiding important parts of the image on larger viewports.  
- The goal is to let the background scale fluidly with viewport width but cap its maximum size so the artwork (scissors) is more visible while preserving responsiveness and layout.

### Description
- Replaced the `cover` sizing for `.services-glance-section` with a clamp-based width-driven sizing: `background-size: clamp(320px, 60vw, 900px) auto;` in `style.css`.  
- Preserved `background-position: right center`, `background-repeat: no-repeat`, and the existing padding/spacing so the section layout remains unchanged.  
- The new `clamp()` approach scales the image with the viewport (`60vw`) while enforcing a minimum (`320px`) and maximum (`900px`) width so it won't overscale on large monitors or become too small on phones.

### Testing
- Started a local HTTP server and captured a headless browser screenshot of `services.html` at `1280x720` using Playwright to visually confirm the change, and the script completed successfully with an artifact saved (`artifacts/services-glance.png`).  
- No automated unit tests were required for this CSS-only change and no failures occurred during the visual capture step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966fa5b2a908322923a5ddddb55f47f)