### PR TITLE
Redesign gallery page editorial layout

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -60,52 +60,63 @@
 
   <main id="main-content" class="site-main" role="main" tabindex="-1">
     <section class="gallery-hero" aria-labelledby="gallery-heading">
-      <div class="gallery-hero-card">
-        <h1 id="gallery-heading" class="display-title" style="margin-top:0;">A Look Inside InJoy Beauty</h1>
-        <p class="gallery-note"><strong>Note:</strong> This will have to wait until next year when I move into a new place — for now I offer only mobile services.</p>
-        <p class="gallery-note">Step inside my sensory-friendly home salon — a calm, welcoming space designed for comfort and accessibility. Here, beauty is about feeling good, not just looking good.</p>
-        <p class="gallery-note" style="margin-top:1.25rem;">Photos will be added soon — check back later.</p>
+      <div class="gallery-hero-grid">
+        <div class="gallery-hero-media">
+          <img src="https://placehold.co/720x900?text=InJoy+Beauty+Studio" alt="A calm, welcoming InJoy Beauty studio vignette">
+        </div>
+        <div class="gallery-hero-content">
+          <h1 id="gallery-heading" class="display-title">A Look Inside InJoy Beauty</h1>
+          <p class="gallery-note"><strong>Note:</strong> This will have to wait until next year when I move into a new place — for now I offer only mobile services.</p>
+          <p class="gallery-note">Step inside my sensory-friendly home salon — a calm, welcoming space designed for comfort and accessibility. Here, beauty is about feeling good, not just looking good.</p>
+          <p class="gallery-note">Photos will be added soon — check back later.</p>
+        </div>
       </div>
     </section>
 
     <section class="gallery-section" aria-labelledby="hair-services-title">
-      <div class="section-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 120" preserveAspectRatio="none" role="presentation" focusable="false">
-          <path fill="#FFE3EC" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
+      <div class="gallery-divider" aria-hidden="true">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+          <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
       <div class="gallery-section-inner">
         <h2 id="hair-services-title" class="section-title display-title">Hair Services</h2>
         <p class="gallery-blurb">(Write-up goes here…)</p>
 
-        <div class="gallery-columns">
-          <div class="gallery-column">
-            <h3 class="display-title">Men</h3>
-            <div class="gallery-column-grid">
-              <figure class="frosted-card">
+        <div class="gallery-collection">
+          <div class="gallery-group">
+            <div class="gallery-group-header">
+              <h3 class="display-title">Men</h3>
+              <p class="gallery-group-note">Classic cuts, textured blends, and tidy finishing details.</p>
+            </div>
+            <div class="gallery-grid">
+              <figure class="gallery-card">
                 <div class="photo-slot">
-                  <img class="gallery-photo" src="https://placehold.co/400x500?text=Men+Hair+1" alt="Men's hair service placeholder">
+                  <img class="gallery-photo" src="https://placehold.co/480x600?text=Men+Hair+1" alt="Men's hair service placeholder">
                 </div>
               </figure>
-              <figure class="frosted-card">
+              <figure class="gallery-card">
                 <div class="photo-slot">
-                  <img class="gallery-photo" src="https://placehold.co/400x500?text=Men+Hair+2" alt="Men's hair service placeholder">
+                  <img class="gallery-photo" src="https://placehold.co/480x600?text=Men+Hair+2" alt="Men's hair service placeholder">
                 </div>
               </figure>
             </div>
           </div>
 
-          <div class="gallery-column">
-            <h3 class="display-title">Women</h3>
-            <div class="gallery-column-grid">
-              <figure class="frosted-card">
+          <div class="gallery-group">
+            <div class="gallery-group-header">
+              <h3 class="display-title">Women</h3>
+              <p class="gallery-group-note">Soft layers, lived-in color moments, and styled finishings.</p>
+            </div>
+            <div class="gallery-grid">
+              <figure class="gallery-card">
                 <div class="photo-slot">
-                  <img class="gallery-photo" src="https://placehold.co/400x500?text=Women+Hair+1" alt="Women's hair service placeholder">
+                  <img class="gallery-photo" src="https://placehold.co/480x600?text=Women+Hair+1" alt="Women's hair service placeholder">
                 </div>
               </figure>
-              <figure class="frosted-card">
+              <figure class="gallery-card">
                 <div class="photo-slot">
-                  <img class="gallery-photo" src="https://placehold.co/400x500?text=Women+Hair+2" alt="Women's hair service placeholder">
+                  <img class="gallery-photo" src="https://placehold.co/480x600?text=Women+Hair+2" alt="Women's hair service placeholder">
                 </div>
               </figure>
             </div>
@@ -114,10 +125,10 @@
       </div>
     </section>
 
-    <section class="gallery-section" aria-labelledby="nail-care-title">
-      <div class="section-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 120" preserveAspectRatio="none" role="presentation" focusable="false">
-          <path fill="#FFE3EC" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
+    <section class="gallery-section gallery-section--alt" aria-labelledby="nail-care-title">
+      <div class="gallery-divider" aria-hidden="true">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+          <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
       <div class="gallery-section-inner">
@@ -125,32 +136,32 @@
         <p class="gallery-blurb">(Write-up goes here…)</p>
 
         <div class="gallery-grid">
-          <figure class="frosted-card">
+          <figure class="gallery-card">
             <div class="photo-slot">
               <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+1" alt="Nail care placeholder">
             </div>
           </figure>
-          <figure class="frosted-card">
+          <figure class="gallery-card">
             <div class="photo-slot">
               <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+2" alt="Nail care placeholder">
             </div>
           </figure>
-          <figure class="frosted-card">
+          <figure class="gallery-card">
             <div class="photo-slot">
               <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+3" alt="Nail care placeholder">
             </div>
           </figure>
-          <figure class="frosted-card">
+          <figure class="gallery-card">
             <div class="photo-slot">
               <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+4" alt="Nail care placeholder">
             </div>
           </figure>
-          <figure class="frosted-card">
+          <figure class="gallery-card">
             <div class="photo-slot">
               <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+5" alt="Nail care placeholder">
             </div>
           </figure>
-          <figure class="frosted-card">
+          <figure class="gallery-card">
             <div class="photo-slot">
               <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+6" alt="Nail care placeholder">
             </div>
@@ -160,9 +171,9 @@
     </section>
 
     <section class="gallery-section" aria-labelledby="extras-title">
-      <div class="section-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 120" preserveAspectRatio="none" role="presentation" focusable="false">
-          <path fill="#FFE3EC" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
+      <div class="gallery-divider" aria-hidden="true">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+          <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
       <div class="gallery-section-inner">
@@ -170,22 +181,22 @@
         <p class="gallery-blurb">(Write-up goes here…)</p>
 
         <div class="gallery-grid">
-          <figure class="frosted-card">
+          <figure class="gallery-card">
             <div class="photo-slot">
               <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+1" alt="Extras placeholder">
             </div>
           </figure>
-          <figure class="frosted-card">
+          <figure class="gallery-card">
             <div class="photo-slot">
               <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+2" alt="Extras placeholder">
             </div>
           </figure>
-          <figure class="frosted-card">
+          <figure class="gallery-card">
             <div class="photo-slot">
               <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+3" alt="Extras placeholder">
             </div>
           </figure>
-          <figure class="frosted-card">
+          <figure class="gallery-card">
             <div class="photo-slot">
               <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+4" alt="Extras placeholder">
             </div>

--- a/style.css
+++ b/style.css
@@ -385,32 +385,72 @@ button:focus-visible {
 /* Gallery layout */
 .gallery-page .gallery-hero {
   max-width: var(--max-width);
-  margin: 1.75rem auto 0;
-  padding: 1rem 1.25rem 0;
+  margin: 2.5rem auto 0;
+  padding: 0 1.25rem 3.5rem;
 }
 
-.gallery-page .gallery-hero-card {
-  background: rgba(255, 255, 255, 0.92);
-  border-radius: 16px;
-  padding: 1.5rem;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.7);
+.gallery-page .gallery-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: clamp(2rem, 5vw, 4rem);
+  align-items: center;
+}
+
+.gallery-page .gallery-hero-media {
+  border-radius: 24px;
+  overflow: hidden;
+  background: #f2e9ef;
+  box-shadow: 0 22px 40px rgba(122, 60, 122, 0.12);
+}
+
+.gallery-page .gallery-hero-media img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  aspect-ratio: 4 / 5;
+  object-fit: cover;
+}
+
+.gallery-page .gallery-hero-content .display-title {
+  margin: 0 0 1rem;
 }
 
 .gallery-page .gallery-note {
-  margin-top: 0.75rem;
+  margin: 0 0 1rem;
   color: var(--muted);
 }
 
 .gallery-page .gallery-section {
   position: relative;
   --divider-height: clamp(70px, 12vw, 130px);
-  padding: calc(3.25rem + var(--divider-height)) 0 3.5rem;
-  background: #f7f0f5;
+  --section-bg: #f7f0f5;
+  --divider-fill: var(--section-bg);
+  padding: calc(3.25rem + var(--divider-height)) 0 4rem;
+  background: var(--section-bg);
 }
 
-.gallery-page .gallery-section:nth-of-type(even) {
-  background: #f5ecf3;
+.gallery-page .gallery-section--alt {
+  --section-bg: #f5ecf3;
+}
+
+.gallery-page .gallery-divider {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--divider-height);
+  display: block;
+  pointer-events: none;
+}
+
+.gallery-page .gallery-divider svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.gallery-page .gallery-divider path {
+  fill: var(--divider-fill);
 }
 
 .gallery-page .gallery-section-inner {
@@ -430,33 +470,17 @@ button:focus-visible {
   color: var(--muted);
 }
 
-.gallery-page .frosted-card {
-  position: relative;
-  border-radius: 18px;
+.gallery-page .gallery-card {
+  border-radius: 20px;
   overflow: hidden;
-  padding: 0.75rem;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
-}
-
-.gallery-page .frosted-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: rgba(255, 255, 255, 0.55);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  z-index: 0;
-}
-
-.gallery-page .frosted-card > * {
-  position: relative;
-  z-index: 1;
+  background: #fff;
+  box-shadow: 0 14px 28px rgba(68, 39, 72, 0.1);
+  border: 1px solid rgba(163, 120, 168, 0.18);
 }
 
 .gallery-page .photo-slot {
   width: 100%;
   aspect-ratio: 4 / 5;
-  border-radius: 12px;
   overflow: hidden;
   background: #f0f0f0;
 }
@@ -468,25 +492,25 @@ button:focus-visible {
   display: block;
 }
 
-.gallery-page .gallery-columns {
+.gallery-page .gallery-collection {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 2rem;
+  gap: 2.5rem;
 }
 
-.gallery-page .gallery-column h3 {
-  margin: 0 0 1rem;
-  font-size: 1.4rem;
+.gallery-page .gallery-group-header {
+  margin-bottom: 1.5rem;
+}
+
+.gallery-page .gallery-group-header h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.35rem;
   color: var(--brand);
 }
 
-.gallery-page .gallery-column-grid {
-  display: grid;
-  gap: 1.25rem;
-}
-
-.gallery-page .gallery-column-grid .frosted-card:nth-child(2) {
-  margin-top: 1.25rem;
+.gallery-page .gallery-group-note {
+  margin: 0;
+  color: var(--muted);
 }
 
 .gallery-page .gallery-grid {
@@ -496,7 +520,11 @@ button:focus-visible {
 }
 
 @media (max-width: 900px) {
-  .gallery-page .gallery-columns {
+  .gallery-page .gallery-hero-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gallery-page .gallery-collection {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
### Motivation
- Rework the Gallery page into an editorial-style layout with a split hero (image + text) to present photography and copy more like an editorial spread. 
- Replace the existing wave divider with a new smoother SVG and a variable-driven system so dividers automatically match alternating section backgrounds. 
- Move away from frosted/glass overlays to clean card surfaces and consistent image aspect ratios for a calmer, more accessible presentation. 

### Description
- Rebuilt the hero into a two-column `gallery-hero-grid` with a large placeholder image in `gallery-hero-media` and textual content in `gallery-hero-content` in `gallery.html`.
- Replaced the old `.section-divider` SVG/path with a new `gallery-divider` element and SVG path (different from the previous path) and added CSS to drive divider fill via `--section-bg` and `--divider-fill` variables per section.
- Removed frosted overlay usage and `frosted-card` patterns and introduced `gallery-card` styling with flat-color backgrounds, borders, and subtle shadows; updated markup to use `gallery-card` and updated `photo-slot`/`gallery-grid` layout for consistent 4:5 aspect ratios.
- Introduced `gallery-section--alt` for alternating backgrounds (`#f7f0f5` / `#f5ecf3`) and ensured `gallery-divider path` uses `fill: var(--divider-fill)` so waves are seamless with no tint/opacity effects.

### Testing
- Launched a local static server with `python -m http.server 8000` and validated the page loads successfully under `http://127.0.0.1:8000/gallery.html` (smoke test).
- Captured a full-page visual snapshot with Playwright at `1400x900` which produced the artifact `artifacts/gallery-page.png`, confirming the new hero, divider, and grid render as expected.
- No automated unit tests were run for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696818bfa7d48322a3710c24283adc48)