### PR TITLE
Fix home page gradient seam

### DIFF
--- a/style.css
+++ b/style.css
@@ -50,12 +50,13 @@ body.site-page {
 }
 
 body.home-page {
+  /* Use a single continuous gradient on the body to avoid seams. */
   background: linear-gradient(
     135deg,
     #FFE3EC 0%,
     #E3FDFF 45%,
-    #E3E3FF 60%,
-    #f7f0f5 60%,
+    #E3E3FF 58%,
+    #f7f0f5 72%,
     #f7f0f5 100%
   );
 }
@@ -356,7 +357,8 @@ button:focus-visible {
   background-size: clamp(320px, 60vw, 900px) auto;
   background-position: right center;
   background-repeat: no-repeat;
-  background-color: #f7f0f5; /* Fallback color */
+  /* Keep transparent so the home gradient remains continuous. */
+  background-color: transparent;
 }
 
 /* Services split divider */


### PR DESCRIPTION
### Motivation
- A visible diagonal seam appeared where the homepage multi-stop gradient met section backgrounds and an identical color-stop caused a hard band. 
- The `.services-glance-section` fallback solid color created a hard edge that interrupted the continuous background.

### Description
- Smooth the `body.home-page` gradient stops by replacing the duplicate `60%` stops with staggered stops (`58%` and `72%`) and add a comment explaining the single-layer gradient. 
- Remove the hard fallback by changing `.services-glance-section` `background-color` from `#f7f0f5` to `transparent` and add a comment so the body gradient shows through. 
- Keep the existing background image (`background.png`) and layout intact while ensuring the gradient is rendered on one layer only (`body`).

### Testing
- Launched a local static server with `python -m http.server` and ran a Playwright script that opened `http://localhost:8000/index.html` and captured a full-page screenshot to `artifacts/home-gradient.png`, which completed successfully. 
- No unit tests were applicable for this visual CSS change; the automated visual capture completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69684308beb88322ad39d4df4726d23b)