### PR TITLE
Fix site backgrounds and add gallery wave dividers

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -82,7 +82,17 @@
       <div class="gallery-section-inner">
         <h2 id="hair-services-title" class="section-title display-title">Hair Services</h2>
         <p class="gallery-blurb">(Write-up goes here…)</p>
+      </div>
+    </section>
 
+    <section class="gallery-section gallery-section--alt" aria-label="Hair services photos">
+      <div class="gallery-divider" aria-hidden="true">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+          <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
+        </svg>
+      </div>
+      <div class="gallery-section-inner">
+        <h2 class="sr-only">Hair services photos</h2>
         <div class="gallery-collection">
           <div class="gallery-group">
             <div class="gallery-group-header">
@@ -125,7 +135,7 @@
       </div>
     </section>
 
-    <section class="gallery-section gallery-section--alt" aria-labelledby="nail-care-title">
+    <section class="gallery-section" aria-labelledby="nail-care-title">
       <div class="gallery-divider" aria-hidden="true">
         <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
           <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
@@ -134,7 +144,17 @@
       <div class="gallery-section-inner">
         <h2 id="nail-care-title" class="section-title display-title">Nail Care</h2>
         <p class="gallery-blurb">(Write-up goes here…)</p>
+      </div>
+    </section>
 
+    <section class="gallery-section gallery-section--alt" aria-label="Nail care photos">
+      <div class="gallery-divider" aria-hidden="true">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+          <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
+        </svg>
+      </div>
+      <div class="gallery-section-inner">
+        <h2 class="sr-only">Nail care photos</h2>
         <div class="gallery-grid">
           <figure class="gallery-card">
             <div class="photo-slot">
@@ -179,7 +199,17 @@
       <div class="gallery-section-inner">
         <h2 id="extras-title" class="section-title display-title">Extras</h2>
         <p class="gallery-blurb">(Write-up goes here…)</p>
+      </div>
+    </section>
 
+    <section class="gallery-section gallery-section--alt" aria-label="Extras photos">
+      <div class="gallery-divider" aria-hidden="true">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+          <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
+        </svg>
+      </div>
+      <div class="gallery-section-inner">
+        <h2 class="sr-only">Extras photos</h2>
         <div class="gallery-grid">
           <figure class="gallery-card">
             <div class="photo-slot">

--- a/style.css
+++ b/style.css
@@ -29,7 +29,7 @@
 }
 
 html, body {
-  height: 100%;
+  min-height: 100%;
 }
 
 body {


### PR DESCRIPTION
### Motivation
- Fix inconsistent/broken page backgrounds so site gradients reliably cover the full page and footer. 
- Add repeating wave dividers between gallery section groups to create a soft visual separation while preserving existing gallery content and layout.

### Description
- Update `style.css` to ensure full-page coverage by changing `html, body` to `min-height: 100%` so body-level gradients span the full document height and behind the footer. 
- Confirmed page body classes are correct (`index.html` uses `class="home-page"`, other pages use `class="site-page"`, and `gallery.html` includes `class="gallery-page site-page"`) so gradients apply predictably. 
- Reworked `gallery.html` structure to alternate text and photo groups: each logical block is wrapped in `.gallery-section` (text) followed by a photo block (either `.gallery-section--alt` or `.gallery-section`) that contains the photo grid; each section boundary includes a repeated `.gallery-divider` SVG wave that reuses the existing wave markup and respects `.gallery-divider path { fill: var(--divider-fill); }`. 
- Kept existing content, headings, image URLs, grids and spacing intact and added small accessibility helpers (`sr-only` headings and `aria-label` where appropriate) so the visual pattern changes do not affect content semantics.

### Testing
- Smoke test: started a local server with `python -m http.server` and loaded `http://127.0.0.1:8000/gallery.html` with a Playwright script which captured a full-page screenshot saved as `artifacts/gallery-waves.png`, and the navigation and rendering completed successfully. 
- No additional automated unit tests required for static HTML/CSS changes; the visual smoke test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69684fbcbae88322b41f3ffba915390d)