### PR TITLE
Restore Services & Home backgrounds; add gallery hero wave divider

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -59,7 +59,7 @@
   </header>
 
   <main id="main-content" class="site-main" role="main" tabindex="-1">
-    <section class="gallery-hero" aria-labelledby="gallery-heading">
+    <section class="gallery-hero" aria-labelledby="gallery-heading" style="position: relative;">
       <div class="gallery-hero-grid">
         <div class="gallery-hero-media">
           <img src="https://placehold.co/720x900?text=InJoy+Beauty+Studio" alt="A calm, welcoming InJoy Beauty studio vignette">
@@ -70,6 +70,11 @@
           <p class="gallery-note">Step inside my sensory-friendly home salon — a calm, welcoming space designed for comfort and accessibility. Here, beauty is about feeling good, not just looking good.</p>
           <p class="gallery-note">Photos will be added soon — check back later.</p>
         </div>
+      </div>
+      <div class="gallery-divider" aria-hidden="true" style="top: auto; bottom: 0; transform: rotate(180deg);">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+          <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
+        </svg>
       </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -40,7 +40,7 @@ body {
   font-family: var(--ui-font);
   color: var(--text);
   line-height: 1.6;
-  background: transparent;
+  background: var(--bg-gradient);
 
   -webkit-font-smoothing: antialiased;
 }
@@ -357,8 +357,7 @@ button:focus-visible {
   background-size: clamp(320px, 60vw, 900px) auto;
   background-position: right center;
   background-repeat: no-repeat;
-  /* Keep transparent so the home gradient remains continuous. */
-  background-color: transparent;
+  background-color: #FFE3EC;
 }
 
 /* Services split divider */
@@ -563,11 +562,11 @@ button:focus-visible {
 }
 
 .services-menu-block {
-  background: rgba(255, 255, 255, 0.35);
+  background: var(--card-bg);
   border-radius: 30px;
   padding: 2rem;
-  border: 1px solid rgba(255, 255, 255, 0.55);
-  box-shadow: 0 12px 30px rgba(122, 60, 122, 0.08);
+  border: 1px solid var(--card-border);
+  box-shadow: var(--card-shadow);
   display: grid;
   gap: 1.75rem;
   backdrop-filter: blur(10px);


### PR DESCRIPTION
### Motivation
- Revert recent styling regressions that flattened the Services menu cards and altered the Home page lower section background while keeping layout and classes unchanged. 
- Add a subtle wave divider between the Gallery hero and the first gallery section without touching gallery layouts or cards.

### Description
- Restored the global page background by setting `body` to use `var(--bg-gradient)` instead of a transparent body-level background. 
- Restored the Home lower section look by setting `.services-glance-section` `background-color` back to `#FFE3EC` while keeping its background image and positioning via `--services-glance-bg`. 
- Reinstated Services menu card visuals by updating `.services-menu-block` to use `--card-bg`, `--card-border`, and `--card-shadow` so `.services-menu-shell`, `.services-menu-block`, `.service-card`, and `.services-note-card` retain the intended card backgrounds, borders, and shadows. 
- Added a wave divider under the Gallery hero by inserting a flipped `.gallery-divider` SVG at the bottom of the hero and made the hero `position: relative;` so the divider aligns correctly; no gallery card/grid styling was changed. 
- Changes were targeted to `style.css` and `gallery.html` only and did not rename classes, alter layout structure, or modify spacing/typography/header/footer styles.

### Testing
- Launched a local static server and used an automated Playwright script to capture full-page screenshots of `index.html`, `services.html`, and `gallery.html`; screenshots were generated successfully. 
- Verified visually (via the automated screenshots) that `.services-menu-block` and `.service-card` show expected card backgrounds/borders/shadows and that `.services-glance-section` displays its background image and color as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968587a116c8322bac66f7aa4005def)