### PR TITLE
Fix wave dividers and responsive backgrounds on Home & Gallery

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -72,7 +72,7 @@
         </div>
       </div>
       <div class="gallery-divider" aria-hidden="true" style="top: auto; bottom: 0; transform: rotate(180deg);">
-        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
           <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
@@ -80,19 +80,24 @@
 
     <section class="gallery-section" aria-labelledby="hair-services-title">
       <div class="gallery-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
           <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
       <div class="gallery-section-inner">
         <h2 id="hair-services-title" class="section-title display-title">Hair Services</h2>
+        <div class="section-title-wave" aria-hidden="true">
+          <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
+            <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
+          </svg>
+        </div>
         <p class="gallery-blurb">(Write-up goes here…)</p>
       </div>
     </section>
 
     <section class="gallery-section gallery-section--alt" aria-label="Hair services photos">
       <div class="gallery-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
           <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
@@ -142,19 +147,24 @@
 
     <section class="gallery-section" aria-labelledby="nail-care-title">
       <div class="gallery-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
           <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
       <div class="gallery-section-inner">
         <h2 id="nail-care-title" class="section-title display-title">Nail Care</h2>
+        <div class="section-title-wave" aria-hidden="true">
+          <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
+            <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
+          </svg>
+        </div>
         <p class="gallery-blurb">(Write-up goes here…)</p>
       </div>
     </section>
 
     <section class="gallery-section gallery-section--alt" aria-label="Nail care photos">
       <div class="gallery-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
           <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
@@ -197,19 +207,24 @@
 
     <section class="gallery-section" aria-labelledby="extras-title">
       <div class="gallery-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
           <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
       <div class="gallery-section-inner">
         <h2 id="extras-title" class="section-title display-title">Extras</h2>
+        <div class="section-title-wave" aria-hidden="true">
+          <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
+            <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
+          </svg>
+        </div>
         <p class="gallery-blurb">(Write-up goes here…)</p>
       </div>
     </section>
 
     <section class="gallery-section gallery-section--alt" aria-label="Extras photos">
       <div class="gallery-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+        <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
           <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
 
     <section class="services-glance-section" aria-labelledby="services-preview-title" style="--services-glance-bg: url('background.png');">
       <div class="section-divider section-divider--top" aria-hidden="true">
-        <svg viewBox="0 0 1440 120" preserveAspectRatio="none" role="presentation" focusable="false">
+        <svg viewBox="0 0 1440 120" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
           <path fill="#FFE3EC" d="M0,0 H1440 V30 C1200,110 900,120 720,100 C480,80 240,70 0,100 Z"></path>
         </svg>
       </div>

--- a/style.css
+++ b/style.css
@@ -354,10 +354,11 @@ button:focus-visible {
   --divider-height: clamp(70px, 12vw, 130px);
   padding: calc(3.5rem + var(--divider-height)) 0 5.75rem;
   background-image: var(--services-glance-bg); /* Use background.png */
-  background-size: clamp(320px, 60vw, 900px) auto;
-  background-position: right center;
+  background-size: cover;
+  background-position: center;
   background-repeat: no-repeat;
   background-color: #FFE3EC;
+  min-height: 420px;
 }
 
 /* Services split divider */
@@ -395,6 +396,7 @@ button:focus-visible {
   max-width: var(--max-width);
   margin: 2.5rem auto 0;
   padding: 0 1.25rem 3.5rem;
+  --divider-fill: #f7f0f5;
 }
 
 .gallery-page .gallery-hero-grid {
@@ -421,11 +423,12 @@ button:focus-visible {
 
 .gallery-page .gallery-hero-content .display-title {
   margin: 0 0 1rem;
+  color: var(--brand);
 }
 
 .gallery-page .gallery-note {
   margin: 0 0 1rem;
-  color: var(--muted);
+  color: var(--brand);
 }
 
 .gallery-page .gallery-section {
@@ -470,12 +473,29 @@ button:focus-visible {
 .gallery-page .section-title {
   margin: 0 0 0.5rem;
   color: var(--brand);
-  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-size: clamp(2rem, 3.4vw, 2.9rem);
+  font-weight: 600;
+}
+
+.gallery-page .section-title-wave {
+  width: 100%;
+  height: clamp(24px, 6vw, 60px);
+  margin: 0.35rem 0 1.5rem;
+}
+
+.gallery-page .section-title-wave svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.gallery-page .section-title-wave path {
+  fill: var(--accent);
 }
 
 .gallery-page .gallery-blurb {
   margin: 0 0 1.75rem;
-  color: var(--muted);
+  color: var(--brand);
 }
 
 .gallery-page .gallery-card {
@@ -506,6 +526,10 @@ button:focus-visible {
   gap: 2.5rem;
 }
 
+.gallery-page .gallery-collection .gallery-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .gallery-page .gallery-group-header {
   margin-bottom: 1.5rem;
 }
@@ -518,7 +542,7 @@ button:focus-visible {
 
 .gallery-page .gallery-group-note {
   margin: 0;
-  color: var(--muted);
+  color: var(--brand);
 }
 
 .gallery-page .gallery-grid {


### PR DESCRIPTION
### Motivation
- Restore the intended wave divider between the hero and Services area so the Home page reads as two visually separated halves.
- Make the Services background image non-stretched and responsive so the lower section keeps a natural focal point across viewports.
- Improve Gallery typography and wave flow so section headings match the brand purple and waves scale cleanly.
- Keep the existing Hair Services layout as a 4-photo row on desktop while keeping responsive stacking on small screens.

### Description
- Updated SVG scaling attributes from `preserveAspectRatio="none"` to `preserveAspectRatio="xMidYMid slice"` for the main wave dividers on the Home and Gallery pages to prevent skew/stretch artifacts across sizes (`index.html`, `gallery.html`).
- Changed the Services preview background to use `background-size: cover; background-position: center; background-repeat: no-repeat;` and added a `min-height: 420px` so the `background.png` displays naturally and responsively (`style.css`).
- Added per-section title waves below main section headings in the Gallery by inserting a `.section-title-wave` SVG block under each relevant `h2` and added CSS rules to size and color those waves (`gallery.html`, `style.css`).
- Tuned Gallery typography colors and weight so heading and body text use the brand purple (`var(--brand)`) and increased section title prominence (`style.css`).
- Stabilized the Hair Services photo grouping by enforcing a 2-column grouping layout for the gallery collection so the four photos present as two-by-two groups on desktop and stack appropriately on smaller screens (`style.css`).
- Files changed: `index.html`, `gallery.html`, `style.css`.

### Testing
- Launched a local static server with `python -m http.server 8000` and ran a Playwright script to capture full-page screenshots of `/index.html` and `/gallery.html` at `1280x720`, which completed successfully and produced screenshot artifacts (`artifacts/home.png`, `artifacts/gallery.png`).
- No unit tests exist for this static HTML/CSS change, and visual confirmation via the screenshots succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690c8d1448832297edf22a99e42a72)