### PR TITLE
Update Gallery wave styling, section colors, spacing, and heading sizes

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -59,31 +59,28 @@
   </header>
 
   <main id="main-content" class="site-main" role="main" tabindex="-1">
-    <section class="gallery-hero" aria-labelledby="gallery-heading" style="position: relative;">
-      <div class="gallery-hero-grid">
-        <div class="gallery-hero-media">
-          <img src="https://placehold.co/720x900?text=InJoy+Beauty+Studio" alt="A calm, welcoming InJoy Beauty studio vignette">
+    <div class="gallery-full-bleed gallery-full-bleed--lavender">
+      <section class="gallery-hero" aria-labelledby="gallery-heading" style="position: relative;">
+        <div class="gallery-hero-grid">
+          <div class="gallery-hero-media">
+            <img src="https://placehold.co/720x900?text=InJoy+Beauty+Studio" alt="A calm, welcoming InJoy Beauty studio vignette">
+          </div>
+          <div class="gallery-hero-content">
+            <h1 id="gallery-heading" class="display-title">A Look Inside InJoy Beauty</h1>
+            <p class="gallery-note"><strong>Note:</strong> This will have to wait until next year when I move into a new place — for now I offer only mobile services.</p>
+            <p class="gallery-note">Step inside my sensory-friendly home salon — a calm, welcoming space designed for comfort and accessibility. Here, beauty is about feeling good, not just looking good.</p>
+            <p class="gallery-note">Photos will be added soon — check back later.</p>
+          </div>
         </div>
-        <div class="gallery-hero-content">
-          <h1 id="gallery-heading" class="display-title">A Look Inside InJoy Beauty</h1>
-          <p class="gallery-note"><strong>Note:</strong> This will have to wait until next year when I move into a new place — for now I offer only mobile services.</p>
-          <p class="gallery-note">Step inside my sensory-friendly home salon — a calm, welcoming space designed for comfort and accessibility. Here, beauty is about feeling good, not just looking good.</p>
-          <p class="gallery-note">Photos will be added soon — check back later.</p>
-        </div>
-      </div>
-      <div class="gallery-divider" aria-hidden="true" style="top: auto; bottom: 0; transform: rotate(180deg);">
+      </section>
+      <div class="gallery-wave gallery-wave--lavender gallery-wave--flip gallery-wave--flush" aria-hidden="true">
         <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
           <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
-    </section>
+    </div>
 
-    <section class="gallery-section" aria-labelledby="hair-services-title">
-      <div class="gallery-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
-          <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
-        </svg>
-      </div>
+    <section class="gallery-section gallery-section--aqua gallery-section--no-top-wave gallery-section--tight-bottom" aria-labelledby="hair-services-title">
       <div class="gallery-section-inner">
         <h2 id="hair-services-title" class="section-title display-title">Hair Services</h2>
         <div class="section-title-wave" aria-hidden="true">
@@ -93,14 +90,14 @@
         </div>
         <p class="gallery-blurb">(Write-up goes here…)</p>
       </div>
-    </section>
-
-    <section class="gallery-section gallery-section--alt" aria-label="Hair services photos">
-      <div class="gallery-divider" aria-hidden="true">
+      <div class="gallery-wave gallery-wave--aqua gallery-wave--spaced" aria-hidden="true">
         <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
           <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
+    </section>
+
+    <section class="gallery-section gallery-section--aqua gallery-section--no-top-wave gallery-section--tight-top" aria-label="Hair services photos">
       <div class="gallery-section-inner">
         <h2 class="sr-only">Hair services photos</h2>
         <div class="gallery-collection">
@@ -145,12 +142,13 @@
       </div>
     </section>
 
-    <section class="gallery-section" aria-labelledby="nail-care-title">
-      <div class="gallery-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
-          <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
-        </svg>
-      </div>
+    <div class="gallery-wave gallery-wave--aqua gallery-wave--flip gallery-wave--flush" aria-hidden="true">
+      <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
+        <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
+      </svg>
+    </div>
+
+    <section class="gallery-section gallery-section--no-top-wave gallery-section--tight-bottom" aria-labelledby="nail-care-title">
       <div class="gallery-section-inner">
         <h2 id="nail-care-title" class="section-title display-title">Nail Care</h2>
         <div class="section-title-wave" aria-hidden="true">
@@ -160,14 +158,14 @@
         </div>
         <p class="gallery-blurb">(Write-up goes here…)</p>
       </div>
-    </section>
-
-    <section class="gallery-section gallery-section--alt" aria-label="Nail care photos">
-      <div class="gallery-divider" aria-hidden="true">
+      <div class="gallery-wave gallery-wave--pink gallery-wave--spaced" aria-hidden="true">
         <svg viewBox="0 0 1440 140" preserveAspectRatio="xMidYMid slice" role="presentation" focusable="false">
           <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
         </svg>
       </div>
+    </section>
+
+    <section class="gallery-section gallery-section--pink gallery-section--no-top-wave gallery-section--tight-top" aria-label="Nail care photos">
       <div class="gallery-section-inner">
         <h2 class="sr-only">Nail care photos</h2>
         <div class="gallery-grid">

--- a/style.css
+++ b/style.css
@@ -399,6 +399,69 @@ button:focus-visible {
 }
 
 /* Gallery layout */
+.gallery-page {
+  overflow-x: clip;
+}
+
+.gallery-page .gallery-full-bleed {
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  background: var(--gallery-bleed-bg, transparent);
+}
+
+.gallery-page .gallery-full-bleed--lavender {
+  --gallery-bleed-bg: #FAF5FF;
+}
+
+.gallery-page .gallery-full-bleed--aqua {
+  --gallery-bleed-bg: #F5FFFF;
+}
+
+.gallery-page .gallery-full-bleed--pink {
+  --gallery-bleed-bg: #FFF5FB;
+}
+
+.gallery-page .gallery-wave {
+  width: 100%;
+  height: clamp(70px, 12vw, 130px);
+  display: block;
+  pointer-events: none;
+}
+
+.gallery-page .gallery-wave svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.gallery-page .gallery-wave path {
+  fill: var(--gallery-wave-fill, #f7f0f5);
+}
+
+.gallery-page .gallery-wave--lavender {
+  --gallery-wave-fill: #FAF5FF;
+}
+
+.gallery-page .gallery-wave--aqua {
+  --gallery-wave-fill: #F5FFFF;
+}
+
+.gallery-page .gallery-wave--pink {
+  --gallery-wave-fill: #FFF5FB;
+}
+
+.gallery-page .gallery-wave--flip {
+  transform: rotate(180deg);
+}
+
+.gallery-page .gallery-wave--spaced {
+  margin-top: 1rem;
+}
+
+.gallery-page .gallery-wave--flush {
+  margin: 0;
+}
+
 .gallery-page .gallery-hero {
   max-width: var(--max-width);
   margin: 2.5rem auto 0;
@@ -449,6 +512,30 @@ button:focus-visible {
 
 .gallery-page .gallery-section--alt {
   --section-bg: #f5ecf3;
+}
+
+.gallery-page .gallery-section--lavender {
+  --section-bg: #FAF5FF;
+}
+
+.gallery-page .gallery-section--aqua {
+  --section-bg: #F5FFFF;
+}
+
+.gallery-page .gallery-section--pink {
+  --section-bg: #FFF5FB;
+}
+
+.gallery-page .gallery-section--no-top-wave {
+  padding-top: 3.25rem;
+}
+
+.gallery-page .gallery-section--tight-top {
+  padding-top: 1.5rem;
+}
+
+.gallery-page .gallery-section--tight-bottom {
+  padding-bottom: 1.5rem;
 }
 
 .gallery-page .gallery-divider {
@@ -543,7 +630,7 @@ button:focus-visible {
 
 .gallery-page .gallery-group-header h3 {
   margin: 0 0 0.5rem;
-  font-size: 1.35rem;
+  font-size: clamp(1.9rem, 3vw, 2.5rem);
   color: var(--brand);
 }
 
@@ -571,6 +658,18 @@ button:focus-visible {
 @media (max-width: 700px) {
   .gallery-page .gallery-section {
     padding: calc(2.75rem + var(--divider-height)) 0 3rem;
+  }
+
+  .gallery-page .gallery-section--no-top-wave {
+    padding-top: 2.75rem;
+  }
+
+  .gallery-page .gallery-section--tight-top {
+    padding-top: 1.25rem;
+  }
+
+  .gallery-page .gallery-section--tight-bottom {
+    padding-bottom: 1.25rem;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Introduce a Gallery-only wave system and colored section backgrounds to create distinct, blended section breaks on the Gallery page without affecting other pages. 
- Move individual wave elements so they associate with the textual write-ups as requested, shorten post-wave spacing to visually blend photos with sections, and make Men/Women labels larger.

### Description
- Added gallery-only wave/full-bleed markup and classes: `.gallery-full-bleed`, `.gallery-wave`, `.gallery-wave--lavender`, `.gallery-wave--aqua`, and `.gallery-wave--pink`, and used them to make the "InJoy Beauty Studio" wave full-viewport and set its background to `#FAF5FF`.
- Repositioned wave markup in `gallery.html` so the Hair Services wave sits under the Hair write-up and the Nail Care wave sits above the Nail heading; also added the new post-Nail spike/wave and applied `#F5FFFF` and `#FFF5FB` section colors respectively.
- Added section modifiers and spacing helpers in `style.css`: `.gallery-section--aqua`, `.gallery-section--pink`, `.gallery-section--lavender`, `.gallery-section--no-top-wave`, `.gallery-section--tight-top`, and `.gallery-section--tight-bottom`, and added `overflow-x: clip` on `.gallery-page` to prevent horizontal scrolling from full-bleed waves.
- Increased Men/Women heading sizing by updating `.gallery-group-header h3` to `font-size: clamp(1.9rem, 3vw, 2.5rem)` and kept all photo markup/ordering/classes intact.

Changed selectors (high level): `.gallery-full-bleed*`, `.gallery-wave*`, `.gallery-section--aqua|--pink|--lavender`, `.gallery-section--no-top-wave`, `.gallery-section--tight-top`, `.gallery-section--tight-bottom`, `.gallery-page { overflow-x }`, and `.gallery-group-header h3` font-size; photo elements/classes were not modified.

### Testing
- Started a local server with `python -m http.server 8000` and executed a Playwright script that visited `http://127.0.0.1:8000/gallery.html` and produced a full-page screenshot at `artifacts/gallery.png`; the script completed successfully.
- No unit tests exist for this static HTML/CSS change, and no other automated test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694a7b572c832294f5a1ff01f2676e)