### PR TITLE
Scope hero gradient to Home Services wave and restore default divider fill

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
     </section>
 
     <section class="services-glance-section" aria-labelledby="services-preview-title" style="--services-glance-bg: url('background.png');">
-     <div class="section-divider" aria-hidden="true">
+     <div class="section-divider section-divider--hero" aria-hidden="true">
   <svg
     viewBox="0 0 1440 120"
     preserveAspectRatio="none"
@@ -107,7 +107,7 @@
   >
     <defs>
       <linearGradient
-        id="heroWaveGradient"
+        id="heroWaveGradientHome"
         x1="0"
         y1="0"
         x2="1"
@@ -121,7 +121,7 @@
 
     <path
       d="M0,64 C240,96 480,32 720,32 960,32 1200,96 1440,64 L1440,0 L0,0 Z"
-      fill="url(#heroWaveGradient)"
+      fill="url(#heroWaveGradientHome)"
     />
   </svg>
 </div>

--- a/style.css
+++ b/style.css
@@ -382,6 +382,10 @@ button:focus-visible {
   height: 100%;
 }
 
+.section-divider:not(.section-divider--hero) path {
+  fill: var(--divider-fill, #f7f0f5);
+}
+
 .services-preview {
   position: relative;
   z-index: 1;


### PR DESCRIPTION
### Motivation
- A recent gradient change caused unstable SVG fill behavior and broke wave fill/layout for the home "Services at a Glance" section. 
- Restore a safe default solid fill for all existing section dividers and apply the hero gradient only to the home services divider. 
- Keep layout, spacing, z-index, and sizing variables unchanged and avoid impacting other pages or waves.

### Description
- Added a modifier class `section-divider--hero` to the services divider in `index.html` and kept the existing structure intact. 
- Scoped the inline SVG gradient by renaming the gradient to `heroWaveGradientHome` and updated the `path` fill to `fill="url(#heroWaveGradientHome)"` in `index.html`. 
- Restored a stable default fill for all other dividers by adding `.section-divider:not(.section-divider--hero) path { fill: var(--divider-fill, #f7f0f5); }` to `style.css`. 
- No layout, spacing, typography, gallery, or other page waves were modified.

### Testing
- Served the site with `python -m http.server 8000` and used a Playwright script to capture `index.html`, producing `artifacts/services-wave.png`, which completed successfully. 
- No automated unit tests were run for this small stylesheet/HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696950e5f3808322babab0a64611d97a)