### PR TITLE
Align hero SVG gradient and standardize gallery waves (full-bleed + per-section fills)

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,21 +107,21 @@
   >
     <defs>
       <linearGradient
-        id="heroWaveGradientHome"
+        id="heroWaveGradient"
         x1="0"
-        y1="0"
+        y1="1"
         x2="1"
-        y2="1"
+        y2="0"
       >
-        <stop offset="0%" stop-color="#F0F7FC" />
-        <stop offset="45%" stop-color="#FFFAFE" />
-        <stop offset="100%" stop-color="#F0F7FC" />
+        <stop offset="0%" stop-color="#FFE3EC" />
+        <stop offset="50%" stop-color="#E3FDFF" />
+        <stop offset="100%" stop-color="#E3E3FF" />
       </linearGradient>
     </defs>
 
     <path
       d="M0,64 C240,96 480,32 720,32 960,32 1200,96 1440,64 L1440,0 L0,0 Z"
-      fill="url(#heroWaveGradientHome)"
+      fill="url(#heroWaveGradient)"
     />
   </svg>
 </div>

--- a/style.css
+++ b/style.css
@@ -380,6 +380,8 @@ button:focus-visible {
 /* Gallery layout */
 .gallery-page {
   overflow-x: clip;
+  --gallery-wave-height: clamp(70px, 12vw, 130px);
+  --gallery-wave-fill: #f7f0f5;
 }
 
 .gallery-page .gallery-full-bleed {
@@ -390,6 +392,7 @@ button:focus-visible {
 
 .gallery-page .gallery-full-bleed--lavender {
   --gallery-bleed-bg: #FAF5FF;
+  --gallery-wave-fill: #FAF5FF;
 }
 
 .gallery-page .gallery-full-bleed--aqua {
@@ -400,21 +403,29 @@ button:focus-visible {
   --gallery-bleed-bg: #FFF5FB;
 }
 
-.gallery-page .gallery-wave {
-  width: 100%;
-  height: clamp(70px, 12vw, 130px);
+.gallery-page .gallery-wave,
+.gallery-page .gallery-divider,
+.gallery-page .section-title-wave {
+  width: 100vw;
+  height: var(--gallery-wave-height, 120px);
   display: block;
   pointer-events: none;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
 }
 
-.gallery-page .gallery-wave svg {
+.gallery-page .gallery-wave svg,
+.gallery-page .gallery-divider svg,
+.gallery-page .section-title-wave svg {
   display: block;
   width: 100%;
   height: 100%;
 }
 
-.gallery-page .gallery-wave path {
-  fill: var(--gallery-wave-fill, #f7f0f5);
+.gallery-page .gallery-wave path,
+.gallery-page .gallery-divider path,
+.gallery-page .section-title-wave path {
+  fill: var(--gallery-wave-fill);
 }
 
 .gallery-page .gallery-wave--lavender {
@@ -429,6 +440,22 @@ button:focus-visible {
   --gallery-wave-fill: #FFF5FB;
 }
 
+.gallery-page .gallery-section--aqua {
+  --gallery-bg: #F5FFFF;
+  --gallery-wave-fill: #F5FFFF;
+}
+
+.gallery-page .gallery-section--pink {
+  --gallery-bg: #FFF5FB;
+  --gallery-wave-fill: #FFF5FB;
+}
+
+.gallery-page .gallery-section--alt {
+  --gallery-bg: #f5ecf3;
+  --gallery-alt-bg: #f5ecf3;
+  --gallery-wave-fill: #f5ecf3;
+}
+
 .gallery-page .gallery-wave--flip {
   transform: rotate(180deg);
 }
@@ -439,6 +466,18 @@ button:focus-visible {
 
 .gallery-page .gallery-wave--flush {
   margin: 0;
+}
+
+.gallery-page .gallery-section--tight-bottom {
+  padding-bottom: 1.75rem;
+}
+
+.gallery-page .gallery-section--tight-top {
+  padding-top: 2rem;
+}
+
+.gallery-page .gallery-group-header .display-title {
+  font-size: clamp(2.1rem, 4vw, 2.8rem);
 }
 
 .gallery-page .gallery-hero {
@@ -464,11 +503,11 @@ button:focus-visible {
   position: relative;
   --divider-height: clamp(70px, 12vw, 130px);
   padding: calc(3.25rem + var(--divider-height)) 0 3.5rem;
-  background: #f7f0f5;
+  background: var(--gallery-bg, #f7f0f5);
 }
 
 .gallery-page .gallery-section:nth-of-type(even) {
-  background: #f5ecf3;
+  background: var(--gallery-alt-bg, #f5ecf3);
 }
 
 .gallery-page .gallery-section-inner {


### PR DESCRIPTION
### Motivation
- Fix a visual mismatch where the homepage hero wave used a different gradient than the hero background, causing the top divider to look off. 
- Make gallery wave dividers render consistently and independently per-section by unifying sizing/fill rules, adding per-section variables, and ensuring full-bleed behavior while keeping gallery photo layout unchanged.

### Description
- Updated the homepage hero SVG in `index.html` to use a single gradient definition `id="heroWaveGradient"` with stops `#FFE3EC`, `#E3FDFF`, and `#E3E3FF`, and changed the path to `fill="url(#heroWaveGradient)"` so the wave matches the hero background exactly.
- Consolidated gallery wave rules in `style.css` by creating a shared wave base applied to `.gallery-wave`, `.gallery-divider`, and `.section-title-wave` with `width: 100vw`, centered negative margins (`margin-left: calc(50% - 50vw)` / `margin-right: calc(50% - 50vw)`), and `height: var(--gallery-wave-height, 120px)` so waves are full-bleed and not clipped.
- Made SVG path fills driven by `--gallery-wave-fill` and added/updated per-section variables such as `--gallery-bg` and `--gallery-wave-fill` for `.gallery-page .gallery-section--aqua`, `.gallery-page .gallery-section--pink`, `.gallery-page .gallery-section--alt`, and the top lavender bleed (`.gallery-full-bleed--lavender`) so each wave matches its section background color independently.
- Applied minimal spacing adjustments and increased the gallery group header title size via `.gallery-section--tight-bottom`, `.gallery-section--tight-top`, and `.gallery-group-header .display-title` without changing the photo grid or card layout.

### Testing
- Started a local static server with `python -m http.server` and verified pages served successfully (server started on port 8000).
- Captured automated full-page screenshots with Playwright for `index.html` and `gallery.html` which completed and produced artifacts `artifacts/home-wave-updated.png` and `artifacts/gallery-waves-updated.png` showing the homepage hero gradient aligned and gallery waves rendering full-bleed with per-section colors (succeeds).
- Changes committed to the repo (two files modified: `index.html` and `style.css`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697055b438832296646864376b4ba1)