### PR TITLE
Update gallery intro layout, first wave placement, and Hair Services grid

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -71,53 +71,44 @@
       </div>
     </section>
 
-    <section class="gallery-section" aria-labelledby="hair-services-title">
-      <div class="gallery-divider" aria-hidden="true">
-        <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
-          <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
-        </svg>
-      </div>
-      <div class="gallery-section-inner">
-        <h2 id="hair-services-title" class="section-title display-title">Hair Services</h2>
-        <p class="gallery-blurb">(Write-up goes here…)</p>
+    <div class="gallery-divider gallery-divider--overlap" aria-hidden="true">
+      <svg viewBox="0 0 1440 140" preserveAspectRatio="none" role="presentation" focusable="false">
+        <path d="M0,70 C180,20 420,15 720,65 C1020,115 1260,120 1440,55 V0 H0 Z"></path>
+      </svg>
+    </div>
 
-        <div class="gallery-collection">
-          <div class="gallery-group">
-            <div class="gallery-group-header">
-              <h3 class="display-title">Men</h3>
-              <p class="gallery-group-note">Classic cuts, textured blends, and tidy finishing details.</p>
-            </div>
-            <div class="gallery-grid">
-              <figure class="gallery-card">
-                <div class="photo-slot">
-                  <img class="gallery-photo" src="https://placehold.co/480x600?text=Men+Hair+1" alt="Men's hair service placeholder">
-                </div>
-              </figure>
-              <figure class="gallery-card">
-                <div class="photo-slot">
-                  <img class="gallery-photo" src="https://placehold.co/480x600?text=Men+Hair+2" alt="Men's hair service placeholder">
-                </div>
-              </figure>
-            </div>
+    <section class="gallery-section gallery-section--aqua gallery-section--no-top-wave" aria-labelledby="hair-services-title">
+      <div class="gallery-section-inner">
+        <div class="gallery-services">
+          <h2 id="hair-services-title" class="section-title display-title">Hair Services</h2>
+          <p class="gallery-blurb">(Write-up goes here…)</p>
+
+          <div class="gallery-services-labels">
+            <span class="gallery-services-label display-title">Men</span>
+            <span class="gallery-services-label display-title">Women</span>
           </div>
 
-          <div class="gallery-group">
-            <div class="gallery-group-header">
-              <h3 class="display-title">Women</h3>
-              <p class="gallery-group-note">Soft layers, lived-in color moments, and styled finishings.</p>
-            </div>
-            <div class="gallery-grid">
-              <figure class="gallery-card">
-                <div class="photo-slot">
-                  <img class="gallery-photo" src="https://placehold.co/480x600?text=Women+Hair+1" alt="Women's hair service placeholder">
-                </div>
-              </figure>
-              <figure class="gallery-card">
-                <div class="photo-slot">
-                  <img class="gallery-photo" src="https://placehold.co/480x600?text=Women+Hair+2" alt="Women's hair service placeholder">
-                </div>
-              </figure>
-            </div>
+          <div class="gallery-services-grid">
+            <figure class="gallery-card">
+              <div class="photo-slot">
+                <img class="gallery-photo" src="https://placehold.co/480x600?text=Men+Hair+1" alt="Men's hair service placeholder">
+              </div>
+            </figure>
+            <figure class="gallery-card">
+              <div class="photo-slot">
+                <img class="gallery-photo" src="https://placehold.co/480x600?text=Men+Hair+2" alt="Men's hair service placeholder">
+              </div>
+            </figure>
+            <figure class="gallery-card">
+              <div class="photo-slot">
+                <img class="gallery-photo" src="https://placehold.co/480x600?text=Women+Hair+1" alt="Women's hair service placeholder">
+              </div>
+            </figure>
+            <figure class="gallery-card">
+              <div class="photo-slot">
+                <img class="gallery-photo" src="https://placehold.co/480x600?text=Women+Hair+2" alt="Women's hair service placeholder">
+              </div>
+            </figure>
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -476,6 +476,10 @@ button:focus-visible {
   padding-top: 2rem;
 }
 
+.gallery-page .gallery-section--no-top-wave {
+  padding-top: 3rem;
+}
+
 .gallery-page .gallery-group-header .display-title {
   font-size: clamp(2.1rem, 4vw, 2.8rem);
 }
@@ -483,7 +487,16 @@ button:focus-visible {
 .gallery-page .gallery-hero {
   max-width: var(--max-width);
   margin: 1.75rem auto 0;
-  padding: 1rem 1.25rem 0;
+  padding: 1rem 1.25rem 2.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.gallery-page .gallery-hero-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(1.5rem, 3vw, 3rem);
+  align-items: center;
 }
 
 .gallery-page .gallery-hero-card {
@@ -592,8 +605,45 @@ button:focus-visible {
   gap: 1.5rem;
 }
 
+.gallery-page .gallery-divider--overlap {
+  margin-top: calc(var(--gallery-wave-height) * -0.45);
+  position: relative;
+  z-index: 2;
+}
+
+.gallery-page .gallery-services {
+  text-align: center;
+}
+
+.gallery-page .gallery-services .gallery-blurb {
+  margin-bottom: 2rem;
+}
+
+.gallery-page .gallery-services-labels {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.gallery-page .gallery-services-label {
+  grid-column: span 2;
+  font-size: clamp(1.4rem, 2.2vw, 1.9rem);
+  color: var(--brand);
+}
+
+.gallery-page .gallery-services-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
 @media (max-width: 900px) {
   .gallery-page .gallery-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .gallery-page .gallery-hero-grid {
     grid-template-columns: 1fr;
   }
 }
@@ -613,6 +663,18 @@ button:focus-visible {
 
   .gallery-page .gallery-section--tight-bottom {
     padding-bottom: 1.25rem;
+  }
+
+  .gallery-page .gallery-services-labels {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .gallery-page .gallery-services-label {
+    grid-column: auto;
+  }
+
+  .gallery-page .gallery-services-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
### Motivation
- Reposition the gallery intro content to sit to the right of the hero photo on desktop and stack on mobile for improved visual balance. 
- Place the first decorative wave directly under the intro block so it partially overlaps the bottom of the hero image and blends with that section. 
- Create a distinct aqua background block immediately below the wave and present the first content area as a focused “Hair Services” section with Men/Women labels and a single responsive four-image row.

### Description
- Updated `gallery.html` to wrap the hero content in a two-column grid (`.gallery-hero-grid`), moved the first wave divider directly beneath the hero as a `div.gallery-divider.gallery-divider--overlap`, and converted the first gallery block to `<section class="gallery-section gallery-section--aqua gallery-section--no-top-wave">` to force the aqua background. 
- Reworked the Hair Services markup into a centered block (`.gallery-services`) with a prominent `Hair Services` heading, a labels row (`.gallery-services-labels`) showing `Men` and `Women`, and a single four-image row (`.gallery-services-grid`) containing 2 Men + 2 Women images. 
- Added CSS in `style.css` to implement the hero two-column layout, overlapping wave offset (`.gallery-divider--overlap`), the `.gallery-section--no-top-wave` spacing tweak, and responsive rules for `.gallery-services-labels` and `.gallery-services-grid` so the four-image row becomes a 2x2 layout on smaller screens while preserving existing card/photo styling.

### Testing
- Launched a local static server with `python -m http.server 8000` and accessed `http://127.0.0.1:8000/gallery.html` to validate layout, which served successfully. 
- Captured an automated visual snapshot with a Playwright script that navigated to the page at `1280x720` and saved `artifacts/gallery-update.png`, which completed successfully and shows the updated hero, overlapping wave, aqua background, and the responsive 4-photo Hair Services row.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69699975f2508322ac2d0f713e5576e5)