### PR TITLE
Redesign gallery: layered hero, before/after paired portfolio, and warm neutral palette

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -59,10 +59,15 @@
   <main id="main-content" class="site-main" role="main" tabindex="-1">
     <section class="gallery-hero" aria-labelledby="gallery-heading">
       <div class="gallery-hero-grid">
-        <div class="gallery-hero-media">
-          <img src="https://placehold.co/720x900?text=InJoy+Beauty+Studio" alt="A calm, welcoming InJoy Beauty studio vignette">
+        <div class="gallery-hero-visual" aria-hidden="true">
+          <div class="gallery-hero-main">
+            <img src="https://placehold.co/900x1100?text=Studio+Backdrop" alt="">
+          </div>
+          <div class="gallery-hero-accent">
+            <img src="https://placehold.co/500x640?text=Signature+Look" alt="">
+          </div>
         </div>
-        <div class="gallery-hero-content">
+        <div class="gallery-hero-card">
           <h1 id="gallery-heading" class="display-title">A Look Inside InJoy Beauty</h1>
           <p class="gallery-note"><strong>Note:</strong> This will have to wait until next year when I move into a new place — for now I offer only mobile services.</p>
           <p class="gallery-note">Step inside my sensory-friendly home salon — a calm, welcoming space designed for comfort and accessibility. Here, beauty is about feeling good, not just looking good.</p>
@@ -81,34 +86,50 @@
       <div class="gallery-section-inner">
         <div class="gallery-services">
           <h2 id="hair-services-title" class="section-title display-title">Hair Services</h2>
-          <p class="gallery-blurb">(Write-up goes here…)</p>
+          <p class="gallery-blurb">A curated look at transformations, from fresh trims to full restyles. Each set pairs the before and after so you can see the full story.</p>
 
-          <div class="gallery-services-labels">
-            <span class="gallery-services-label display-title">Men</span>
-            <span class="gallery-services-label display-title">Women</span>
-          </div>
+          <div class="gallery-pairs">
+            <article class="gallery-pair">
+              <div class="gallery-pair-images">
+                <figure class="gallery-pair-card">
+                  <span class="gallery-pair-label">Before</span>
+                  <img class="gallery-photo" src="https://placehold.co/520x720?text=Hair+Before+1" alt="Before: hair service placeholder">
+                </figure>
+                <figure class="gallery-pair-card">
+                  <span class="gallery-pair-label">After</span>
+                  <img class="gallery-photo" src="https://placehold.co/520x720?text=Hair+After+1" alt="After: hair service placeholder">
+                </figure>
+              </div>
+              <p class="gallery-pair-blurb">Soft layers and warm dimension created a lighter, airy finish that still keeps movement natural.</p>
+            </article>
 
-          <div class="gallery-services-grid">
-            <figure class="gallery-card">
-              <div class="photo-slot">
-                <img class="gallery-photo" src="https://placehold.co/480x600?text=Men+Hair+1" alt="Men's hair service placeholder">
+            <article class="gallery-pair">
+              <div class="gallery-pair-images">
+                <figure class="gallery-pair-card">
+                  <span class="gallery-pair-label">Before</span>
+                  <img class="gallery-photo" src="https://placehold.co/520x720?text=Hair+Before+2" alt="Before: hair service placeholder">
+                </figure>
+                <figure class="gallery-pair-card">
+                  <span class="gallery-pair-label">After</span>
+                  <img class="gallery-photo" src="https://placehold.co/520x720?text=Hair+After+2" alt="After: hair service placeholder">
+                </figure>
               </div>
-            </figure>
-            <figure class="gallery-card">
-              <div class="photo-slot">
-                <img class="gallery-photo" src="https://placehold.co/480x600?text=Men+Hair+2" alt="Men's hair service placeholder">
+              <p class="gallery-pair-blurb">A bold chop with textured ends kept the look playful while framing the face and enhancing curl.</p>
+            </article>
+
+            <article class="gallery-pair">
+              <div class="gallery-pair-images">
+                <figure class="gallery-pair-card">
+                  <span class="gallery-pair-label">Before</span>
+                  <img class="gallery-photo" src="https://placehold.co/520x720?text=Hair+Before+3" alt="Before: hair service placeholder">
+                </figure>
+                <figure class="gallery-pair-card">
+                  <span class="gallery-pair-label">After</span>
+                  <img class="gallery-photo" src="https://placehold.co/520x720?text=Hair+After+3" alt="After: hair service placeholder">
+                </figure>
               </div>
-            </figure>
-            <figure class="gallery-card">
-              <div class="photo-slot">
-                <img class="gallery-photo" src="https://placehold.co/480x600?text=Women+Hair+1" alt="Women's hair service placeholder">
-              </div>
-            </figure>
-            <figure class="gallery-card">
-              <div class="photo-slot">
-                <img class="gallery-photo" src="https://placehold.co/480x600?text=Women+Hair+2" alt="Women's hair service placeholder">
-              </div>
-            </figure>
+              <p class="gallery-pair-blurb">Gentle highlights and a precision trim helped bring out shine while keeping the texture soft.</p>
+            </article>
           </div>
         </div>
       </div>
@@ -122,39 +143,36 @@
       </div>
       <div class="gallery-section-inner">
         <h2 id="nail-care-title" class="section-title display-title">Nail Care</h2>
-        <p class="gallery-blurb">(Write-up goes here…)</p>
+        <p class="gallery-blurb">Elegant nail transformations with a clean, elevated finish. Each set highlights a before and after for clarity.</p>
 
-        <div class="gallery-grid">
-          <figure class="gallery-card">
-            <div class="photo-slot">
-              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+1" alt="Nail care placeholder">
+        <div class="gallery-pairs">
+          <article class="gallery-pair">
+            <div class="gallery-pair-images">
+              <figure class="gallery-pair-card">
+                <span class="gallery-pair-label">Before</span>
+                <img class="gallery-photo" src="https://placehold.co/520x720?text=Nails+Before+1" alt="Before: nail care placeholder">
+              </figure>
+              <figure class="gallery-pair-card">
+                <span class="gallery-pair-label">After</span>
+                <img class="gallery-photo" src="https://placehold.co/520x720?text=Nails+After+1" alt="After: nail care placeholder">
+              </figure>
             </div>
-          </figure>
-          <figure class="gallery-card">
-            <div class="photo-slot">
-              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+2" alt="Nail care placeholder">
+            <p class="gallery-pair-blurb">Refined cuticle work and a milky nude finish brought back a polished, healthy look.</p>
+          </article>
+
+          <article class="gallery-pair">
+            <div class="gallery-pair-images">
+              <figure class="gallery-pair-card">
+                <span class="gallery-pair-label">Before</span>
+                <img class="gallery-photo" src="https://placehold.co/520x720?text=Nails+Before+2" alt="Before: nail care placeholder">
+              </figure>
+              <figure class="gallery-pair-card">
+                <span class="gallery-pair-label">After</span>
+                <img class="gallery-photo" src="https://placehold.co/520x720?text=Nails+After+2" alt="After: nail care placeholder">
+              </figure>
             </div>
-          </figure>
-          <figure class="gallery-card">
-            <div class="photo-slot">
-              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+3" alt="Nail care placeholder">
-            </div>
-          </figure>
-          <figure class="gallery-card">
-            <div class="photo-slot">
-              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+4" alt="Nail care placeholder">
-            </div>
-          </figure>
-          <figure class="gallery-card">
-            <div class="photo-slot">
-              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+5" alt="Nail care placeholder">
-            </div>
-          </figure>
-          <figure class="gallery-card">
-            <div class="photo-slot">
-              <img class="gallery-photo" src="https://placehold.co/420x525?text=Nail+Care+6" alt="Nail care placeholder">
-            </div>
-          </figure>
+            <p class="gallery-pair-blurb">A soft almond shape with a dusty rose polish keeps the set timeless and flattering.</p>
+          </article>
         </div>
       </div>
     </section>
@@ -167,29 +185,36 @@
       </div>
       <div class="gallery-section-inner">
         <h2 id="extras-title" class="section-title display-title">Extras</h2>
-        <p class="gallery-blurb">(Write-up goes here…)</p>
+        <p class="gallery-blurb">Detail work, add-ons, and special requests that complete the look. Each pairing shows the transformation.</p>
 
-        <div class="gallery-grid">
-          <figure class="gallery-card">
-            <div class="photo-slot">
-              <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+1" alt="Extras placeholder">
+        <div class="gallery-pairs">
+          <article class="gallery-pair">
+            <div class="gallery-pair-images">
+              <figure class="gallery-pair-card">
+                <span class="gallery-pair-label">Before</span>
+                <img class="gallery-photo" src="https://placehold.co/520x720?text=Extras+Before+1" alt="Before: extra service placeholder">
+              </figure>
+              <figure class="gallery-pair-card">
+                <span class="gallery-pair-label">After</span>
+                <img class="gallery-photo" src="https://placehold.co/520x720?text=Extras+After+1" alt="After: extra service placeholder">
+              </figure>
             </div>
-          </figure>
-          <figure class="gallery-card">
-            <div class="photo-slot">
-              <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+2" alt="Extras placeholder">
+            <p class="gallery-pair-blurb">Natural-looking brow shaping and soft tinting bring balance to the overall style.</p>
+          </article>
+
+          <article class="gallery-pair">
+            <div class="gallery-pair-images">
+              <figure class="gallery-pair-card">
+                <span class="gallery-pair-label">Before</span>
+                <img class="gallery-photo" src="https://placehold.co/520x720?text=Extras+Before+2" alt="Before: extra service placeholder">
+              </figure>
+              <figure class="gallery-pair-card">
+                <span class="gallery-pair-label">After</span>
+                <img class="gallery-photo" src="https://placehold.co/520x720?text=Extras+After+2" alt="After: extra service placeholder">
+              </figure>
             </div>
-          </figure>
-          <figure class="gallery-card">
-            <div class="photo-slot">
-              <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+3" alt="Extras placeholder">
-            </div>
-          </figure>
-          <figure class="gallery-card">
-            <div class="photo-slot">
-              <img class="gallery-photo" src="https://placehold.co/420x525?text=Extras+4" alt="Extras placeholder">
-            </div>
-          </figure>
+            <p class="gallery-pair-blurb">A gentle lash lift gives extra definition without needing heavy mascara or extensions.</p>
+          </article>
         </div>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -24,10 +24,11 @@
   --card-shadow: 0 18px 45px rgba(0, 0, 0, 0.08);
   
   /* Gallery section colors */
-  --gallery-intro-bg: #FFFFFF;
-  --gallery-hair-bg: #FFF7FF;
-  --gallery-nail-bg: #FCF7FF;
-  --gallery-extras-bg: #F7FFFA;
+  --gallery-intro-bg: #f8f2ec;
+  --gallery-hair-bg: #f1e7df;
+  --gallery-nail-bg: #eee3dc;
+  --gallery-extras-bg: #f3e6e2;
+  --gallery-accent: #d7b3aa;
 }
 
 * {
@@ -110,6 +111,7 @@ button:focus-visible {
   width: 100%;
   z-index: 999;
   background: transparent;
+  backdrop-filter: none;
   transition: background 0.25s ease, backdrop-filter 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
   border-bottom: 1px solid transparent;
 }
@@ -499,7 +501,7 @@ button:focus-visible {
 .gallery-page .gallery-hero {
   width: 100vw;
   margin: 1.75rem calc(50% - 50vw) 0;
-  padding: 1rem 1.25rem 2.5rem;
+  padding: 2.5rem 1.25rem 3.25rem;
   background: var(--gallery-intro-bg); /* Intro section - white */
   position: relative;
   z-index: 1;
@@ -508,18 +510,57 @@ button:focus-visible {
 .gallery-page .gallery-hero-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(1.5rem, 3vw, 3rem);
+  gap: clamp(1.5rem, 4vw, 3.75rem);
   align-items: center;
   max-width: var(--max-width);
   margin: 0 auto; /* Fix: removed duplicate padding/margin that caused visual duplication */
 }
 
+.gallery-page .gallery-hero-visual {
+  position: relative;
+  padding: clamp(1rem, 3vw, 2rem);
+  background: #fdfaf7;
+  border-radius: 26px;
+  box-shadow: 0 22px 40px rgba(36, 20, 10, 0.08);
+  border: 1px solid rgba(100, 75, 60, 0.12);
+  min-height: 420px;
+  display: grid;
+  place-items: center;
+}
+
+.gallery-page .gallery-hero-main {
+  width: min(420px, 90%);
+  aspect-ratio: 3 / 4;
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow: 0 18px 32px rgba(60, 40, 30, 0.16);
+}
+
+.gallery-page .gallery-hero-accent {
+  position: absolute;
+  left: clamp(1.5rem, 6vw, 3rem);
+  bottom: clamp(1.5rem, 5vw, 2.75rem);
+  width: min(230px, 42%);
+  aspect-ratio: 3 / 4;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 8px solid #fdf7f3;
+  box-shadow: 0 20px 30px rgba(43, 28, 20, 0.18);
+}
+
+.gallery-page .gallery-hero-visual img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
 .gallery-page .gallery-hero-card {
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(255, 255, 255, 0.88);
   border-radius: 16px;
-  padding: 1.5rem;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.7);
+  padding: 1.75rem;
+  box-shadow: 0 18px 36px rgba(40, 20, 10, 0.12);
+  border: 1px solid rgba(122, 90, 70, 0.2);
 }
 
 .gallery-page .gallery-note {
@@ -555,29 +596,6 @@ button:focus-visible {
   color: var(--muted);
 }
 
-.gallery-page .frosted-card {
-  position: relative;
-  border-radius: 18px;
-  overflow: hidden;
-  padding: 0.75rem;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
-}
-
-.gallery-page .frosted-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: rgba(255, 255, 255, 0.55);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  z-index: 0;
-}
-
-.gallery-page .frosted-card > * {
-  position: relative;
-  z-index: 1;
-}
-
 .gallery-page .photo-slot {
   width: 100%;
   aspect-ratio: 4 / 5;
@@ -593,31 +611,47 @@ button:focus-visible {
   display: block;
 }
 
-.gallery-page .gallery-columns {
+.gallery-page .gallery-pairs {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.gallery-page .gallery-pair {
+  display: grid;
+  gap: 1rem;
+}
+
+.gallery-page .gallery-pair-images {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 2rem;
-}
-
-.gallery-page .gallery-column h3 {
-  margin: 0 0 1rem;
-  font-size: 1.4rem;
-  color: var(--brand);
-}
-
-.gallery-page .gallery-column-grid {
-  display: grid;
-  gap: 1.25rem;
-}
-
-.gallery-page .gallery-column-grid .frosted-card:nth-child(2) {
-  margin-top: 1.25rem;
-}
-
-.gallery-page .gallery-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1.5rem;
+}
+
+.gallery-page .gallery-pair-card {
+  position: relative;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #f9f5f1;
+  box-shadow: 0 16px 30px rgba(45, 25, 15, 0.12);
+}
+
+.gallery-page .gallery-pair-label {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 999px;
+  color: #6a4a40;
+}
+
+.gallery-page .gallery-pair-blurb {
+  margin: 0;
+  color: var(--muted);
+  max-width: 70ch;
 }
 
 .gallery-page .gallery-divider--overlap {
@@ -635,32 +669,17 @@ button:focus-visible {
   margin-bottom: 2rem;
 }
 
-.gallery-page .gallery-services-labels {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.gallery-page .gallery-services-label {
-  grid-column: span 2;
-  font-size: clamp(1.4rem, 2.2vw, 1.9rem);
-  color: var(--brand);
-}
-
-.gallery-page .gallery-services-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1.5rem;
-}
-
 @media (max-width: 900px) {
-  .gallery-page .gallery-columns {
+  .gallery-page .gallery-hero-grid {
     grid-template-columns: 1fr;
   }
 
-  .gallery-page .gallery-hero-grid {
-    grid-template-columns: 1fr;
+  .gallery-page .gallery-hero-card {
+    order: 2;
+  }
+
+  .gallery-page .gallery-hero-visual {
+    order: 1;
   }
 }
 
@@ -681,16 +700,19 @@ button:focus-visible {
     padding-bottom: 1rem;
   }
 
-  .gallery-page .gallery-services-labels {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .gallery-page .gallery-pair-images {
+    grid-template-columns: 1fr;
   }
 
-  .gallery-page .gallery-services-label {
-    grid-column: auto;
+  .gallery-page .gallery-hero-visual {
+    padding: 1.5rem;
   }
 
-  .gallery-page .gallery-services-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .gallery-page .gallery-hero-accent {
+    position: static;
+    width: min(260px, 70%);
+    margin-top: 1.5rem;
+    border-width: 6px;
   }
 }
 


### PR DESCRIPTION
### Motivation

- Introduce a layered, editorial hero with a stacked mobile layout and preserve the large heading with supporting copy. 
- Replace dense photo grids with clear before/after paired sets that include subtle labels and short blurbs to show client transformations. 
- Move the gallery toward warm neutrals with a dusty pink accent and ensure the header is fully transparent by default while retaining a frosted blur when scrolled.

### Description

- Reworked the hero markup in `gallery.html` to a two-column layout with a visual stack (`.gallery-hero-visual`, `.gallery-hero-main`, `.gallery-hero-accent`) and a separate content card (`.gallery-hero-card`).
- Replaced service photo grids with semantic paired markup (`.gallery-pairs`, `.gallery-pair`, `.gallery-pair-images`, `.gallery-pair-card`, `.gallery-pair-label`, `.gallery-pair-blurb`) across hair, nails, and extras sections in `gallery.html`.
- Updated `style.css` with a warm neutral palette (`--gallery-intro-bg`, `--gallery-hair-bg`, `--gallery-nail-bg`, `--gallery-extras-bg`, `--gallery-accent`), added styling for the hero visuals and pair cards, adjusted spacing and shadows, and removed the older grid/frosted-card layout rules no longer needed.
- Kept the header transparent by default via `background: transparent` and `backdrop-filter: none` on `.site-header`, while the frosted blur is applied only to `.site-header.is-scrolled` to preserve the scroll frosted effect.

### Testing

- Started a local server with `python -m http.server 8000` and ran a Playwright script to capture desktop and mobile screenshots, which completed successfully and produced `artifacts/gallery-desktop.png` and `artifacts/gallery-mobile.png`.
- Static build and quick visual verification were performed; no automated test failures occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bc64730a08322b412136873faab04)